### PR TITLE
Update integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,9 @@ on:
   pull_request_target:
   # manual trigger
   workflow_dispatch:
+  # run this once per night to ensure no regressions from latest dbt-core changes
+  schedule:
+    - cron: '0 5 * * *' # 5 UTC
 
 # explicitly turn off permissions for `GITHUB_TOKEN`
 permissions: read-all
@@ -74,21 +77,6 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Check if relevant files changed
-        # https://github.com/marketplace/actions/paths-changes-filter
-        # For each filter, it sets output variable named by the filter to the text:
-        #  'true' - if any of changed files matches any of filter rules
-        #  'false' - if none of changed files matches any of filter rules
-        # also, returns:
-        #  `changes` - JSON array with names of all filters matching any of the changed files
-        uses: dorny/paths-filter@v2
-        id: get-changes
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          filters: |
-            redshift:
-              - 'dbt/**'
-              - 'tests/**'
       - name: Generate integration test matrix
         id: generate-matrix
         uses: actions/github-script@v4

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core + dbt-postgres
-# TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt.git@develop#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt.git@develop#egg=dbt-postgres&subdirectory=plugins/postgres
+# TODO: how to switch from HEAD to x.y.latest branches after minor releases?
+git+https://github.com/dbt-labs/dbt.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt.git#egg=dbt-postgres&subdirectory=plugins/postgres
 
 bumpversion
 flake8


### PR DESCRIPTION
Partial resolution of dbt-labs/dbt#3924. If we agree with the approach here, we can extend to `dbt-snowflake` + `dbt-bigquery`.

- Run the `integration` workflow nightly at 5 UTC, to identify any regressions caused by changes in `dbt-core`.
- Install `dbt-core` from `HEAD` (instead of hardcoding `develop` branch) to get latest changes
- Remove logic from `integration` workflow that picks plugins to test based on file changes. This is nice for PRs that only edit the README, but it's not as important now that this repo only contains the Redshift plugin. This logic seemed to be running into bugginess on `push` triggers ([e.g.](https://github.com/dbt-labs/dbt-redshift/runs/3777004562)); we'll be able to see after merging this PR.