### PR TITLE
Bump artifact versions in tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -159,6 +159,14 @@ jobs:
           pip --version
           tox --version
 
+      - name: Install dbt-core latest
+        run: |
+          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
+
+      - name: Install dbt-postgres latest
+        run: |
+          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres"
+
       - name: Run tox (redshift)
         if: matrix.adapter == 'redshift'
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,14 @@ jobs:
           pip --version
           tox --version
 
+      - name: Install dbt-core latest
+        run: |
+          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
+
+      - name: Install dbt-postgres latest
+        run: |
+          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres"
+
       - name: Run tox
         run: tox
 

--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -646,7 +646,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         )
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
@@ -1261,7 +1261,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         snapshot_path = self.dir('snapshot/snapshot_seed.sql')
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v3.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
@@ -1525,7 +1525,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             elif key == 'metadata':
                 metadata = manifest['metadata']
                 self.verify_metadata(
-                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v3.json')
+                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v4.json')
                 assert 'project_id' in metadata and metadata[
                     'project_id'] == '098f6bcd4621d373cade4e832627b4f6'
                 assert 'send_anonymous_usage_stats' in metadata and metadata[
@@ -1621,7 +1621,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         run_results = _read_json('./target/run_results.json')
         assert 'metadata' in run_results
         self.verify_metadata(
-            run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v3.json')
+            run_results['metadata'], 'https://schemas.getdbt.com/dbt/run-results/v4.json')
         self.assertIn('elapsed_time', run_results)
         self.assertGreater(run_results['elapsed_time'], 0)
         self.assertTrue(

--- a/tests/integration/sources_test/test_sources.py
+++ b/tests/integration/sources_test/test_sources.py
@@ -141,7 +141,7 @@ class TestSourceFreshness(SuccessfulSourcesTest):
         assert isinstance(data['elapsed_time'], float)
         self.assertBetween(data['metadata']['generated_at'],
                            self.freshness_start_time)
-        assert data['metadata']['dbt_schema_version'] == 'https://schemas.getdbt.com/dbt/sources/v2.json'
+        assert data['metadata']['dbt_schema_version'] == 'https://schemas.getdbt.com/dbt/sources/v3.json'
         assert data['metadata']['dbt_version'] == dbt.version.__version__
         assert data['metadata']['invocation_id'] == dbt.tracking.active_user.invocation_id
         key = 'key'


### PR DESCRIPTION
This is a bad test to have in the adapter plugin, we should remove or change it in the long run. For now, manual updates.