### PR TITLE
Fire typed events in `tests.integration.base` instead of AdapterLogger

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -25,11 +25,14 @@ from dbt.logger import log_manager
 from dbt.events.functions import (
     capture_stdout_logs, fire_event, setup_event_logger, stop_capture_stdout_logs
 )
-from dbt.events import AdapterLogger
+from dbt.events.test_types import (
+    IntegrationTestInfo,
+    IntegrationTestDebug,
+    IntegrationTestException
+)
 from dbt.contracts.graph.manifest import Manifest
 
 
-logger = AdapterLogger("Redshift")
 INITIAL_ROOT = os.getcwd()
 
 
@@ -239,7 +242,7 @@ class DBTIntegrationTest(unittest.TestCase):
                 'test_original_source_path={0.test_original_source_path}',
                 'test_root_dir={0.test_root_dir}'
             )).format(self)
-            logger.exception(msg)
+            fire_event(IntegrationTestException(msg=msg))
 
             # if logging isn't set up, I still really want this message.
             print(msg)
@@ -349,8 +352,8 @@ class DBTIntegrationTest(unittest.TestCase):
         try:
             shutil.rmtree(self.test_root_dir)
         except EnvironmentError:
-            logger.exception('Could not clean up after test - {} not removable'
-                             .format(self.test_root_dir))
+            msg = f"Could not clean up after test - {self.test_root_dir} not removable"
+            fire_event(IntegrationTestException(msg=msg))
 
     def _get_schema_fqn(self, database, schema):
         schema_fqn = self.quote_as_configured(schema, 'schema')
@@ -441,7 +444,8 @@ class DBTIntegrationTest(unittest.TestCase):
             final_args.extend(['--profiles-dir', self.test_root_dir])
         final_args.append('--log-cache-events')
 
-        logger.info("Invoking dbt with {}".format(final_args))
+        msg = f"Invoking dbt with {final_args}"
+        fire_event(IntegrationTestInfo(msg=msg))
         return dbt.handle_and_check(final_args)
 
     def run_sql_file(self, path, kwargs=None):
@@ -495,7 +499,8 @@ class DBTIntegrationTest(unittest.TestCase):
         sql = self.transform_sql(query, kwargs=kwargs)
 
         with self.get_connection(connection_name) as conn:
-            logger.debug('test connection "{}" executing: {}'.format(conn.name, sql))
+            msg = f'test connection "{conn.name}" executing: {sql}'
+            fire_event(IntegrationTestDebug(msg=msg))
             return self.run_sql_common(sql, fetch, conn)
 
     def _ilike(self, target, value):


### PR DESCRIPTION
Nightly runs have been failing since https://github.com/dbt-labs/dbt-core/pull/4266 was merged:
- https://github.com/dbt-labs/dbt-redshift/actions/runs/1474953855
- https://github.com/dbt-labs/dbt-redshift/actions/runs/1470106194

In particular, a handful of tests that use `--vars` were failing here:
```python
tests/integration/simple_snapshot_test/test_simple_snapshot.py:95: in _run_snapshot_test
    self.run_dbt(['snapshot', '--vars', '{seed_name: seed_newcol}'])
tests/integration/base.py:409: in run_dbt
    res, success = self.run_dbt_and_check(args=args, profiles_dir=profiles_dir)
tests/integration/base.py:444: in run_dbt_and_check
    logger.info("Invoking dbt with {}".format(final_args))
```
Complaining about key errors in the `*args` being passed along:
```python
>       msg = self.base_msg.format(*self.args)
E       KeyError: 'seed_name'
```

I'm guessing this has to do with the lazy evaluation for log messages that we spent time pulling apart and understanding in https://github.com/dbt-labs/dbt-core/pull/4266. I'm just surprised this started failing _after_ we merged those fixes.

For the time being, I was able to get these tests passing again locally by making `tests/integration/base.py` look more like it does in dbt-core: fire typed events (`IntegrationTestInfo`, `IntegrationTestDebug`, `IntegrationTestException`), instead of plumbing through `AdapterLogger`.

We very badly need to (a) improve this integration testing scaffold, and (b) consolidate its logic into a single module (package?) that can be reused across core + all our adapters. For now, these need to be manual fixups.