### PR TITLE
Fixing Action to post test failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -217,10 +217,10 @@ jobs:
             "needs to label this PR with `ok to test` in order to run integration tests!"
           check_for_duplicate_msg: true
 
-  slack-results:
+  post-failure:
     runs-on: ubuntu-latest
     needs: test 
-    if: always()
+    if: ${{ failure() }}
 
     steps:
       - name: Posting scheduled run failures
@@ -229,6 +229,5 @@ jobs:
         with:
           notification_title: 'Redshift nightly integration test failed'
           status: ${{ job.status }}
-          notify_when: 'failure'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
The `notify_when` field doesn't act how I thought it was supposed to. It looks at failures in the current job but not other jobs upstream which is what we want.

Previous logic: Always run post job, but only post if failures
New logic: Only run post job on failures, but always post