### PR TITLE
Fixing version bump bug

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -22,4 +22,6 @@ values =
 [bumpversion:part:num]
 first_value = 1
 
+[bumpversion:file:setup.py]
+
 [bumpversion:file:dbt/adapters/redshift/__version__.py]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 import re
 
-# require python 3.6 or newer
+# require python 3.7 or newer
 if sys.version_info < (3, 7):
     print('Error: dbt does not support this version of Python.')
     print('Please upgrade to Python 3.7 or higher.')
@@ -43,11 +43,6 @@ def _get_plugin_version_dict():
         return match.groupdict()
 
 
-def _get_plugin_version():
-    parts = _get_plugin_version_dict()
-    return "{major}.{minor}.{patch}{prekind}{pre}".format(**parts)
-
-
 # require a compatible minor version (~=), prerelease if this is a prerelease
 def _get_dbt_core_version():
     parts = _get_plugin_version_dict()
@@ -57,7 +52,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-redshift"
-package_version = _get_plugin_version()
+package_version = "1.0.0"
 dbt_core_version = _get_dbt_core_version()
 description = """The Redshift adapter plugin for dbt"""
 


### PR DESCRIPTION
resolves #50 

### Description

This fixes the issue with the package naming bug we saw when we released and there was no `rc` or `b` appended to the end. Instead this just relies on versionBump to get the package version

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.