### PR TITLE
[Backport] #80 to unstick releases for adapters

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -151,7 +151,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
+      - name: Get dbt-core version
+        # if this is a pull request uses ref of base branch otherwise uses ref of current commit
+        id: dbt-core-version
+        run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request_target' && github.base_ref || github.ref }}"
       - name: Install python dependencies
         run: |
           pip install  --user --upgrade pip
@@ -159,13 +162,13 @@ jobs:
           pip --version
           tox --version
 
-      - name: Install dbt-core latest
+      - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
         run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
+          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
 
-      - name: Install dbt-postgres latest
+      - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
         run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres"
+          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
       - name: Run tox (redshift)
         if: matrix.adapter == 'redshift'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
+      - name: Get dbt-core version
+        # if this is a pull request uses ref of base branch otherwise uses ref of current commit
+        id: dbt-core-version
+        run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}"
       - name: Install python dependencies
         run: |
           pip install  --user --upgrade pip
@@ -101,13 +104,13 @@ jobs:
           pip --version
           tox --version
 
-      - name: Install dbt-core latest
+      - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
         run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core"
+          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
 
-      - name: Install dbt-postgres latest
+      - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
         run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres"
+          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
       - name: Run tox
         run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,10 +93,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get dbt-core version
-        # if this is a pull request uses ref of base branch otherwise uses ref of current commit
-        id: dbt-core-version
-        run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}"
+      # - name: Get dbt-core version
+      #   # if this is a pull request uses ref of base branch otherwise uses ref of current commit
+      #   id: dbt-core-version
+      #   run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}"
       - name: Install python dependencies
         run: |
           pip install  --user --upgrade pip
@@ -104,13 +104,13 @@ jobs:
           pip --version
           tox --version
 
-      - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
+      # - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
+      #   run: |
+      #     pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
 
-      - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
+      # - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
+      #   run: |
+      #     pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
       - name: Run tox
         run: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## dbt-redshift 1.0.1 (TBD)
+
+### Fixes
+
+### Under the hood
+- install compatible branch of dbt-core in unit/integration tests based on merge target ([#80](https://github.com/dbt-labs/dbt-redshift/pull/80))
+
 ## dbt-redshift 1.0.0 (December 3, 2021)
 
 ## dbt-redshift 1.0.0rc2 (November 24, 2021)

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core + dbt-postgres
 # TODO: how to switch from HEAD to x.y.latest branches after minor releases?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.0.latest#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@1.0.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 
 bumpversion
 flake8


### PR DESCRIPTION
resolves #80 second half in which we need to control what branches our pr's tests against



### Description
Pulls in #80 to latest branch to clear up tests against wrong branches. 


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.