### PR TITLE
remove unneeded dbt-core installs in action as test run based off tox…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -151,24 +151,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get dbt-core version
-        # if this is a pull request uses ref of base branch otherwise uses ref of current commit
-        id: dbt-core-version
-        run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request_target' && github.base_ref || github.ref }}"
+
       - name: Install python dependencies
         run: |
           pip install  --user --upgrade pip
           pip install tox
           pip --version
           tox --version
-
-      - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
-
-      - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
       - name: Run tox (redshift)
         if: matrix.adapter == 'redshift'
@@ -222,7 +211,7 @@ jobs:
 
   post-failure:
     runs-on: ubuntu-latest
-    needs: test 
+    needs: test
     if: ${{ failure() }}
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,24 +93,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Get dbt-core version
-        # if this is a pull request uses ref of base branch otherwise uses ref of current commit
-        id: dbt-core-version
-        run: echo "::set-output name=dbt-core-ref::${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}"
+
       - name: Install python dependencies
         run: |
           pip install  --user --upgrade pip
           pip install tox
           pip --version
           tox --version
-
-      - name: Install dbt-core from branch ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-core&subdirectory=core"
-
-      - name: Install dbt-postgres from ${{ steps.dbt-core-version.outputs.dbt-core-ref }}
-        run: |
-          pip install "git+https://github.com/dbt-labs/dbt-core.git@${{ steps.dbt-core-version.outputs.dbt-core-ref }}#egg=dbt-postgres&subdirectory=plugins/postgres"
 
       - name: Run tox
         run: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add unique\_id field to docs generation test catalogs; a follow-on PR to core PR ([#4168](https://github.com/dbt-labs/dbt-core/pull/4618)) and core PR ([#4701](https://github.com/dbt-labs/dbt-core/pull/4701))
 
 ### Under the hood
-- Install compatible branch of dbt-core in unit/integration tests based on merge target ([#80](https://github.com/dbt-labs/dbt-redshift/pull/80))
+- Removes unused installs of dbt-core outside of tox env as it clutters up gha and can lead to misunderstanding of which version of dbt-core is being installed.([#90](https://github.com/dbt-labs/dbt-redshift/pull/90))
 - Add stale pr/issue github action ([#65](https://github.com/dbt-labs/dbt-redshift/pull/65))
 - Add env example file ([#69](https://github.com/dbt-labs/dbt-redshift/pull/69))
 


### PR DESCRIPTION
resolves # 80

### Description

Removes unused installs of dbt-core outside of tox env as it clutters up gha and can lead to misunderstanding of which version of dbt-core is being installed.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.