### PR TITLE
Bump to 1.2.0a1. Skip `test-build` step during alpha

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0b1
+current_version = 1.2.0a1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,6 @@ jobs:
         run: ./scripts/build-dist.sh
 
       - name: Show distributions
-        id: show-distributions
         run: ls -lh dist/
 
       - name: Check distribution descriptions

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,10 @@ jobs:
           echo "is_alpha: $is_alpha"
           echo "::set-output name=is_alpha::$(is_alpha)"
 
+      - name: Show distributions
+        id: show-distributions
+        run: ls -lh dist/
+
       - name: Check distribution descriptions
         run: |
           twine check dist/*
@@ -160,6 +164,12 @@ jobs:
       - name: Check wheel contents
         run: |
           check-wheel-contents dist/*.whl --ignore W007,W008
+          
+      - name: Check if this is an alpha version
+        id: check-is-alpha
+        export is_alpha=0
+        if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
+        echo "::set-output name=is_alpha::$is_alpha"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,9 @@ jobs:
     name: build packages
 
     runs-on: ubuntu-latest
+    
+    outputs:
+      is_alpha: ${{ steps.show-distributions.outputs.is_alpha }}
 
     steps:
       - name: Check out the repository
@@ -141,7 +144,14 @@ jobs:
         run: ./scripts/build-dist.sh
 
       - name: Show distributions
-        run: ls -lh dist/
+        id: show-distributions
+        run: |
+          DISTS=$(ls -lh dist/)
+          echo "$dists"
+          export is_alpha=0
+          if [[ "$dists" == *"a1"* ]]; then export is_alpha=1; fi
+          echo "is_alpha: $is_alpha"
+          echo "::set-output name=is_alpha::$(is_alpha)"
 
       - name: Check distribution descriptions
         run: |
@@ -158,6 +168,8 @@ jobs:
 
   test-build:
     name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }}
+
+    if: needs.build.outputs.is_alpha == 0
 
     needs: build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     
     outputs:
-      is_alpha: ${{ steps.show-distributions.outputs.is_alpha }}
+      is_alpha: ${{ steps.check-is-alpha.outputs.is_alpha }}
 
     steps:
       - name: Check out the repository
@@ -145,16 +145,6 @@ jobs:
 
       - name: Show distributions
         id: show-distributions
-        run: |
-          DISTS=$(ls -lh dist/)
-          echo "$dists"
-          export is_alpha=0
-          if [[ "$dists" == *"a1"* ]]; then export is_alpha=1; fi
-          echo "is_alpha: $is_alpha"
-          echo "::set-output name=is_alpha::$(is_alpha)"
-
-      - name: Show distributions
-        id: show-distributions
         run: ls -lh dist/
 
       - name: Check distribution descriptions
@@ -167,9 +157,10 @@ jobs:
           
       - name: Check if this is an alpha version
         id: check-is-alpha
-        export is_alpha=0
-        if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
-        echo "::set-output name=is_alpha::$is_alpha"
+        run: |
+          export is_alpha=0
+          if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
+          echo "::set-output name=is_alpha::$is_alpha"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/dbt/adapters/redshift/__version__.py
+++ b/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = '1.1.0b1'
+version = '1.2.0a1'

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-redshift"
-package_version = "1.1.0b1"
+package_version = "1.2.0a1"
 dbt_core_version = _get_dbt_core_version()
 description = """The Redshift adapter plugin for dbt"""
 

--- a/tests/integration/docs_generate_tests/test_docs_generate.py
+++ b/tests/integration/docs_generate_tests/test_docs_generate.py
@@ -648,7 +648,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         )
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v5.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
@@ -1267,7 +1267,7 @@ class TestDocsGenerate(DBTIntegrationTest):
         snapshot_path = self.dir('snapshot/snapshot_seed.sql')
 
         return {
-            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v4.json',
+            'dbt_schema_version': 'https://schemas.getdbt.com/dbt/manifest/v5.json',
             'dbt_version': dbt.version.__version__,
             'nodes': {
                 'model.test.model': {
@@ -1533,7 +1533,7 @@ class TestDocsGenerate(DBTIntegrationTest):
             elif key == 'metadata':
                 metadata = manifest['metadata']
                 self.verify_metadata(
-                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v4.json')
+                    metadata, 'https://schemas.getdbt.com/dbt/manifest/v5.json')
                 assert 'project_id' in metadata and metadata[
                     'project_id'] == '098f6bcd4621d373cade4e832627b4f6'
                 assert 'send_anonymous_usage_stats' in metadata and metadata[

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -218,6 +218,7 @@ REQUIRED_MACRO_KEYS = REQUIRED_QUERY_HEADER_KEYS | {
     'sql',
     'sql_now',
     'adapter_macro',
+    'selected_resources',
 }
 REQUIRED_MODEL_KEYS = REQUIRED_MACRO_KEYS | {'this'}
 MAYBE_KEYS = frozenset({'debug'})


### PR DESCRIPTION
- Bump `main` to `1.2.0a1`
- Skip the `test-build` step while in alpha, since we don't expect this to work (no PyPI distribution for `dbt-core==1.2.0a1`)