### PR TITLE
Updating to test py 3.9 and 3.10

### DIFF
--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -1,6 +1,6 @@
 module.exports = ({ context }) => {
   const defaultPythonVersion = "3.8";
-  const supportedPythonVersions = ["3.7", "3.8", "3.9"];
+  const supportedPythonVersions = ["3.7", "3.8", "3.9", "3.10"];
   const supportedAdapters = ["redshift"];
 
   // if PR, generate matrix based on files changed and PR labels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8] # TODO: support unit testing for python 3.9 (https://github.com/dbt-labs/dbt/issues/3689)
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     env:
       TOXENV: "unit"
@@ -172,7 +172,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,14 +4,14 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
 
-black==21.12b0
+black==22.3.0
 click~=8.0.4
 bumpversion
 flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.782
+mypy==0.942
 pip-tools
 pre-commit
 pytest

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     python_requires=">=3.7",
 )

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import traceback
 import unittest
+import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
@@ -218,6 +219,13 @@ class DBTIntegrationTest(unittest.TestCase):
         return normalize(tempfile.mkdtemp(prefix='dbt-int-test-'))
 
     def setUp(self):
+        # Logbook warnings are ignored so we don't have to fork logbook to support python 3.10. 
+        # This _only_ works for tests in `test/integration`.
+        warnings.filterwarnings(
+            "ignore",
+            category=DeprecationWarning,
+            module="logbook"
+        )
         self.dbt_core_install_root = os.path.dirname(dbt.__file__)
         log_manager.reset_handlers()
         self.initial_dir = INITIAL_ROOT

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310
 
-[testenv:{unit,py37,py38,py39,py}]
+[testenv:{unit,py37,py38,py39,py310,py}]
 description = unit testing
 skip_install = true
 passenv = DBT_* PYTEST_ADDOPTS
@@ -11,7 +11,7 @@ deps =
   -rdev_requirements.txt
   -e.
 
-[testenv:{integration,py37,py38,py39,py}-{redshift}]
+[testenv:{integration,py37,py38,py39,py310,py}-{redshift}]
 description = adapter plugin integration testing
 skip_install = true
 passenv = DBT_* REDSHIFT_TEST_* PYTEST_ADDOPTS


### PR DESCRIPTION
### Description
We should add Python 3.10 to our test runs. I had to upgrade some dependencies to make it work. I'm guessing those older versions weren't 3.10 compatible. I also added the suppression of logbook warnings like we did in dbt-core 

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.
