### PR TITLE
Grantee env vars for GitHub Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -130,6 +130,9 @@ jobs:
       TOXENV: integration-${{ matrix.adapter }}
       PYTEST_ADDOPTS: "-v --color=yes -n4 --csv integration_results.csv"
       DBT_INVOCATION_ENV: github-actions
+      DBT_TEST_USER_1: dbt_test_user_1
+      DBT_TEST_USER_2: dbt_test_user_2
+      DBT_TEST_USER_3: dbt_test_user_3
 
     steps:
       - name: Check out the repository


### PR DESCRIPTION
### Description

Environment variables don't appear to be loading in https://github.com/dbt-labs/dbt-redshift/pull/131 for some reason. This PR is a low-risk experiment to add the relevant GitHub Actions config to the default branch in the hopes that it will load these environment variables when running CI going forward.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.
