### PR TITLE
Adding max parallel jobs to integration CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -124,7 +124,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 3
       matrix: ${{ fromJSON(needs.test-metadata.outputs.matrix) }}
 
     env:


### PR DESCRIPTION
### Description
Our integration tests are seeing timeouts from Redshift and it might be that we are hammering them too hard (running 12 parallel integration test jobs at once) so this would but back how many jobs we allow at a single time to run 

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-redshift next" section.
