### PR TITLE
Rename compiled_sql to compiled_code

### DIFF
--- a/tests/integration/defer_state_test/test_defer_state.py
+++ b/tests/integration/defer_state_test/test_defer_state.py
@@ -71,8 +71,8 @@ class TestDeferState(DBTIntegrationTest):
 
         # with state it should work though
         results = self.run_dbt(['run', '-m', 'view_model', '--state', 'state', '--defer', '--target', 'otherschema'])
-        assert self.other_schema not in results[0].node.compiled_sql
-        assert self.unique_schema() in results[0].node.compiled_sql
+        assert self.other_schema not in results[0].node.compiled_code
+        assert self.unique_schema() in results[0].node.compiled_code
 
         with open('target/manifest.json') as fp:
             data = json.load(fp)
@@ -123,8 +123,8 @@ class TestDeferState(DBTIntegrationTest):
         assert len(results) == 2
 
         # because the seed now exists in our schema, we shouldn't defer it
-        assert self.other_schema not in results[0].node.compiled_sql
-        assert self.unique_schema() in results[0].node.compiled_sql
+        assert self.other_schema not in results[0].node.compiled_code
+        assert self.unique_schema() in results[0].node.compiled_code
 
     def run_defer_deleted_upstream(self):
         results = self.run_dbt(['seed'])
@@ -145,8 +145,8 @@ class TestDeferState(DBTIntegrationTest):
 
         # despite deferral, test should use models just created in our schema
         results = self.run_dbt(['test', '--state', 'state', '--defer'])
-        assert self.other_schema not in results[0].node.compiled_sql
-        assert self.unique_schema() in results[0].node.compiled_sql
+        assert self.other_schema not in results[0].node.compiled_code
+        assert self.unique_schema() in results[0].node.compiled_code
 
     @use_profile('redshift')
     def test_redshift_state_changetarget(self):


### PR DESCRIPTION
Any chance this does it? :)

Longer term:
- convert this test
- we probably don't even need it in `dbt-redshift`