### PR TITLE
Add other macros to redshift which depend on make_relation_with_suffix.

### DIFF
--- a/.changes/unreleased/Fixes-20220811-122924.yaml
+++ b/.changes/unreleased/Fixes-20220811-122924.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Add missing macros to complete PR 149.
+time: 2022-08-11T12:29:24.802344-07:00
+custom:
+  Author: mquesta
+  Issue: "5568"
+  PR: "164"

--- a/dbt/include/redshift/macros/adapters.sql
+++ b/dbt/include/redshift/macros/adapters.sql
@@ -254,6 +254,14 @@
                                               "database": none})) }}
 {% endmacro %}
 
+{% macro redshift__make_intermediate_relation(base_relation, suffix) %}
+    {{ return(redshift__make_relation_with_suffix(base_relation, suffix, dstring=False)) }}
+{% endmacro %}
+
+{% macro redshift__make_backup_relation(base_relation, backup_relation_type, suffix) %}
+    {% set backup_relation = redshift__make_relation_with_suffix(base_relation, suffix, dstring=False) %}
+    {{ return(backup_relation.incorporate(type=backup_relation_type)) }}
+{% endmacro %}
 
 {% macro redshift__persist_docs(relation, model, for_relation, for_columns) -%}
   {% if for_relation and config.persist_relation_docs() and model.description %}


### PR DESCRIPTION

### Description

Adds missing macros to redshift that should force dependence on logic implemented in #149 .

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
