### PR TITLE
add test for column precision change

### DIFF
--- a/.changes/unreleased/Under the Hood-20220812-151707.yaml
+++ b/.changes/unreleased/Under the Hood-20220812-151707.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Add test for column precision changes
+time: 2022-08-12T15:17:07.183316-07:00
+custom:
+  Author: epapineau
+  Issue: "5351"
+  PR: "166"

--- a/tests/test_incremental_run_result.py
+++ b/tests/test_incremental_run_result.py
@@ -1,0 +1,6 @@
+import pytest
+
+from dbt.tests.adapter.basic.test_incremental import BaseIncrementalNotSchemaChange
+
+class TestBaseIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
+    pass


### PR DESCRIPTION
resolves #5351 (dbt-core). Test shorter columns are not considered a schema change for incremental materialization when `on_schema_change = sync_all_columns`

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

<!--- Describe the Pull Request here -->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
