### PR TITLE
Configure more connection retries for CI tests

### DIFF
--- a/.changes/unreleased/Under the Hood-20220824-102919.yaml
+++ b/.changes/unreleased/Under the Hood-20220824-102919.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Configure more connection retries for CI tests
+time: 2022-08-24T10:29:19.107341-05:00
+custom:
+  Author: McKnight-42
+  Issue: "142"
+  PR: "000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def dbt_profile_target():
     return {
         'type': 'redshift',
         'threads': 1,
-        'retries': 2,
+        'retries': 6,
         'host': os.getenv('REDSHIFT_TEST_HOST'),
         'port': int(os.getenv('REDSHIFT_TEST_PORT')),
         'user': os.getenv('REDSHIFT_TEST_USER'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ def dbt_profile_target():
     return {
         'type': 'redshift',
         'threads': 1,
+        'retries': 2,
         'host': os.getenv('REDSHIFT_TEST_HOST'),
         'port': int(os.getenv('REDSHIFT_TEST_PORT')),
         'user': os.getenv('REDSHIFT_TEST_USER'),

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -153,6 +153,7 @@ class DBTIntegrationTest(unittest.TestCase):
                     'default2': {
                         'type': 'redshift',
                         'threads': 1,
+                        'retries': 2,
                         'host': os.getenv('REDSHIFT_TEST_HOST'),
                         'port': int(os.getenv('REDSHIFT_TEST_PORT')),
                         'user': os.getenv('REDSHIFT_TEST_USER'),
@@ -219,7 +220,7 @@ class DBTIntegrationTest(unittest.TestCase):
         return normalize(tempfile.mkdtemp(prefix='dbt-int-test-'))
 
     def setUp(self):
-        # Logbook warnings are ignored so we don't have to fork logbook to support python 3.10. 
+        # Logbook warnings are ignored so we don't have to fork logbook to support python 3.10.
         # This _only_ works for tests in `test/integration`.
         warnings.filterwarnings(
             "ignore",

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -153,7 +153,7 @@ class DBTIntegrationTest(unittest.TestCase):
                     'default2': {
                         'type': 'redshift',
                         'threads': 1,
-                        'retries': 2,
+                        'retries': 6,
                         'host': os.getenv('REDSHIFT_TEST_HOST'),
                         'port': int(os.getenv('REDSHIFT_TEST_PORT')),
                         'user': os.getenv('REDSHIFT_TEST_USER'),


### PR DESCRIPTION
resolves #142 


### Description

Configure more connection retries for CI tests since upstream adapter has exponential backoff

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
