### PR TITLE
Revert "Bump mypy from 0.942 to 0.971 (#141)"

### DIFF
--- a/.changes/unreleased/Dependency-20220902-150437.yaml
+++ b/.changes/unreleased/Dependency-20220902-150437.yaml
@@ -1,7 +1,0 @@
-kind: Dependency
-body: "Bump mypy from 0.942 to 0.971"
-time: 2022-09-02T15:04:37.00000Z
-custom:
-  Author: dependabot[bot]
-  Issue: 150
-  PR: 141

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ flake8
 flaky
 freezegun==0.3.12
 ipdb
-mypy==0.971
+mypy==0.942
 pip-tools
 pre-commit
 pytest


### PR DESCRIPTION
### Description
I think the mypy version bump might have caused CI to fail. Testing that here.

EDIT: nope, still fails with the reversion.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
