### PR TITLE
Change keepalives idle field to numbers appropriate for minutes, not seconds.

### DIFF
--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -48,7 +48,7 @@ class RedshiftCredentials(PostgresCredentials):
     iam_profile: Optional[str] = None
     iam_duration_seconds: int = 900
     search_path: Optional[str] = None
-    keepalives_idle: int = 240
+    keepalives_idle: int = 4
     autocreate: bool = False
     db_groups: List[str] = field(default_factory=list)
     ra3_node: Optional[bool] = False

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -184,13 +184,13 @@ class TestRedshiftAdapter(unittest.TestCase):
             password='password',
             port=5439,
             connect_timeout=10,
-            keepalives_idle=240,
+            keepalives_idle=4,
             application_name='dbt'
         )
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
     def test_changed_keepalive(self, psycopg2):
-        self.config.credentials = self.config.credentials.replace(keepalives_idle=256)
+        self.config.credentials = self.config.credentials.replace(keepalives_idle=5)
         connection = self.adapter.acquire_connection('dummy')
 
         psycopg2.connect.assert_not_called()
@@ -202,7 +202,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password='password',
             port=5439,
             connect_timeout=10,
-            keepalives_idle=256,
+            keepalives_idle=5,
             application_name='dbt')
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
@@ -220,7 +220,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             connect_timeout=10,
             options="-c search_path=test",
-            keepalives_idle=240,
+            keepalives_idle=4,
             application_name='dbt')
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')
@@ -238,7 +238,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             connect_timeout=10,
             options=r"-c search_path=test\ test",
-            keepalives_idle=240,
+            keepalives_idle=4,
             application_name='dbt')
 
     @mock.patch('dbt.adapters.postgres.connections.psycopg2')


### PR DESCRIPTION


### Description

> Do we set the Redshift session timeout_sec to 14400?  I have a customer that is seeing a large number of connections (336) during a 4 thread job run, and I am wondering if we are not reusing connections and a bunch are just idle and not timing out early enough.. Thoughts?

We supplied fields on the scale of seconds. It should instead be minutes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
