### PR TITLE
Pin full commit sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
     needs: build-test-package
 
     # pin to commit since this is workflow is WIP but this commit has been tested as working
-    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d
+    uses: dbt-labs/dbt-release/.github/workflows/github-release.yml@7b6e01d73d2c8454e06302cc66ef4c2dbd4dbe4e
 
     with:
       sha: ${{ inputs.sha }}


### PR DESCRIPTION
### Description

I previously pinned to the shorthand SHA but the full sha is required.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
