### PR TITLE
Support external tables in get_relation

### DIFF
--- a/.changes/unreleased/Fixes-20230120-013726.yaml
+++ b/.changes/unreleased/Fixes-20230120-013726.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: get_relation method returns an identifier for external tables
+time: 2023-01-20T01:37:26.785447-05:00
+custom:
+  Author: mattyb
+  Issue: "17"
+  PR: "273"

--- a/dbt/include/redshift/macros/adapters.sql
+++ b/dbt/include/redshift/macros/adapters.sql
@@ -198,7 +198,17 @@
 
 
 {% macro redshift__list_relations_without_caching(schema_relation) %}
-  {{ return(postgres__list_relations_without_caching(schema_relation)) }}
+  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+    select
+      database_name as database,
+      table_name as name,
+      schema_name as schema,
+      lower(table_type) as type
+    from pg_catalog.svv_all_tables
+    where schema_name ilike '{{ schema_relation.schema }}'
+      and database_name ilike '{{ schema_relation.database }}'
+  {% endcall %}
+  {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
 
 


### PR DESCRIPTION
resolves #17

### Description

Implements `redshift__list_relations_without_caching` directly instead of inheriting the postgres implementation. We use [`SVV_ALL_TABLES`](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_ALL_TABLES.html) which includes internal tables and views as well as external tables. This allows `adapter.get_reference` to successfully discover external tables.

It's worth considering that this moves the query from the leader node to compute nodes, subjecting it to queuing, but the adapter uses views like this in several places already.

I've tested this locally with a model, but this repository doesn't appear to be set up for testing external relations. We could copy the paradigm in @dbt-labs/dbt-external-tables (https://github.com/dbt-labs/dbt-external-tables/blob/main/integration_tests/macros/plugins/redshift/prep_external.sql), but this would require anyone running integration tests locally to also have IAM permissions and a glue database set up. If that's the right direction, I can add the setup and tests to this PR.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
