### PR TITLE
Fix grant and revoke for Redshift grantees with special characters

### DIFF
--- a/.changes/unreleased/Fixes-20230126-112628.yaml
+++ b/.changes/unreleased/Fixes-20230126-112628.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Fix grant and revoke for Redshift grantees containing special characters
+time: 2023-01-26T11:26:28.9178898+01:00
+custom:
+  Author: mp24-git
+  Issue: "277"
+  PR: "282"

--- a/dbt/include/redshift/macros/adapters/apply_grants.sql
+++ b/dbt/include/redshift/macros/adapters/apply_grants.sql
@@ -25,3 +25,21 @@ where has_table_privilege(u.usename, '{{ relation }}', privilege_type)
     and not u.usesuper
 
 {% endmacro %}
+
+
+{%- macro redshift__get_grant_sql(relation, privilege, grantees) -%}
+    grant {{ privilege }} on {{ relation }} to
+    {% for grantee in grantees %}
+    {{ adapter.quote(grantee) }}
+    {% if not loop.last %},{% endif %}
+    {% endfor %}
+{%- endmacro -%}
+
+
+{%- macro redshift__get_revoke_sql(relation, privilege, grantees) -%}
+    revoke {{ privilege }} on {{ relation }} from
+    {% for grantee in grantees %}
+    {{ adapter.quote(grantee) }}
+    {% if not loop.last %},{% endif %}
+    {% endfor %}
+{%- endmacro -%}


### PR DESCRIPTION
resolves #277 and addresses https://github.com/dbt-labs/dbt-core/issues/6444 for Redshift

### Description
Grantees in the `grant` and `revoke` SQL commands in Redshift can be quoted using double quotes. This avoids issues with user names that contain special characters such as `.` or `:` (in case of IAM role grants).

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
