### PR TITLE
[BACKPORT] Remove PR requirement from Changelog (#280)

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -72,8 +72,8 @@ custom:
   minLength: 3
 - key: Issue
   label: GitHub Issue Number (separated by a single space if multiple)
-  type: int
-  minLength: 4
+  type: string
+  minLength: 1
 
 footerFormat: |
   {{- $contributorDict := dict }}
@@ -87,19 +87,28 @@ footerFormat: |
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
         {{- $changeList := splitList " " $change.Custom.Author }}
+          {{- $IssueList := list }}
           {{- $changeLink := $change.Kind }}
           {{- if or (eq $change.Kind "Dependencies") (eq $change.Kind "Security") }}
-            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-redshift/pull/nbr)" | replace "nbr" $change.Custom.PR }}
+            {{- $changes := splitList " " $change.Custom.PR }}
+            {{- range $issueNbr := $changes }}
+              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-redshift/pull/nbr)" | replace "nbr" $issueNbr }}
+              {{- $IssueList = append $IssueList $changeLink  }}
+            {{- end -}}
           {{- else }}
-            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-redshift/issues/nbr)" | replace "nbr" $change.Custom.Issue }}
+            {{- $changes := splitList " " $change.Custom.Issue }}
+            {{- range $issueNbr := $changes }}
+              {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-redshift/issues/nbr)" | replace "nbr" $issueNbr }}
+              {{- $IssueList = append $IssueList $changeLink  }}
+            {{- end -}}
           {{- end }}
           {{- /* check if this contributor has other changes associated with them already */}}
           {{- if hasKey $contributorDict $author }}
             {{- $contributionList := get $contributorDict $author }}
-            {{- $contributionList = append $contributionList $changeLink  }}
+            {{- $contributionList = concat $contributionList $IssueList  }}
             {{- $contributorDict := set $contributorDict $author $contributionList }}
           {{- else }}
-            {{- $contributionList := list $changeLink }}
+            {{- $contributionList := $IssueList }}
             {{- $contributorDict := set $contributorDict $author $contributionList }}
           {{- end }}
         {{- end}}

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,57 +6,109 @@ changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## dbt-redshift {{.Version}} - {{.Time.Format "January 02, 2006"}}'
 kindFormat: '### {{.Kind}}'
-changeFormat: '- {{.Body}} ([#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-redshift/issues/{{.Custom.Issue}}), [#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-redshift/pull/{{.Custom.PR}}))'
+changeFormat: |-
+  {{- $IssueList := list }}
+  {{- $changes := splitList " " $.Custom.Issue }}
+  {{- range $issueNbr := $changes }}
+    {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-redshift/issues/nbr)" | replace "nbr" $issueNbr }}
+    {{- $IssueList = append $IssueList $changeLink  }}
+  {{- end -}}
+  - {{.Body}} ({{ range $index, $element := $IssueList }}{{if $index}}, {{end}}{{$element}}{{end}})
 kinds:
 - label: Breaking Changes
 - label: Features
 - label: Fixes
 - label: Under the Hood
 - label: Dependencies
-  changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-redshift/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-redshift/pull/{{.Custom.PR}}))'
+  changeFormat: |-
+    {{- $PRList := list }}
+    {{- $changes := splitList " " $.Custom.PR }}
+    {{- range $pullrequest := $changes }}
+      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-redshift/pull/nbr)" | replace "nbr" $pullrequest }}
+      {{- $PRList = append $PRList $changeLink  }}
+    {{- end -}}
+    - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
+  skipGlobalChoices: true
+  additionalChoices:
+    - key: Author
+      label: GitHub Username(s) (separated by a single space if multiple)
+      type: string
+      minLength: 3
+    - key: PR
+      label: GitHub Pull Request Number (separated by a single space if multiple)
+      type: string
+      minLength: 1
 - label: Security
-  changeFormat: '- {{.Body}} ({{if ne .Custom.Issue ""}}[#{{.Custom.Issue}}](https://github.com/dbt-labs/dbt-redshift/issues/{{.Custom.Issue}}), {{end}}[#{{.Custom.PR}}](https://github.com/dbt-labs/dbt-redshift/pull/{{.Custom.PR}}))'
+  changeFormat: |-
+    {{- $PRList := list }}
+    {{- $changes := splitList " " $.Custom.PR }}
+    {{- range $pullrequest := $changes }}
+      {{- $changeLink := "[#nbr](https://github.com/dbt-labs/dbt-redshift/pull/nbr)" | replace "nbr" $pullrequest }}
+      {{- $PRList = append $PRList $changeLink  }}
+    {{- end -}}
+    - {{.Body}} ({{ range $index, $element := $PRList }}{{if $index}}, {{end}}{{$element}}{{end}})
+  skipGlobalChoices: true
+  additionalChoices:
+    - key: Author
+      label: GitHub Username(s) (separated by a single space if multiple)
+      type: string
+      minLength: 3
+    - key: PR
+      label: GitHub Pull Request Number (separated by a single space if multiple)
+      type: string
+      minLength: 1
+
+newlines:
+  afterChangelogHeader: 1
+  afterKind: 1
+  afterChangelogVersion: 1
+  beforeKind: 1
+  endOfVersion: 1
+
 custom:
 - key: Author
   label: GitHub Username(s) (separated by a single space if multiple)
   type: string
   minLength: 3
 - key: Issue
-  label: GitHub Issue Number
+  label: GitHub Issue Number (separated by a single space if multiple)
   type: int
   minLength: 4
-- key: PR
-  label: GitHub Pull Request Number
-  type: int
-  minLength: 4
+
 footerFormat: |
   {{- $contributorDict := dict }}
   {{- /* any names added to this list should be all lowercase for later matching purposes */}}
-  {{- $core_team := list "michelleark" "peterallenwebb" "emmyoop" "nathaniel-may" "gshank" "leahwicz" "chenyulinx" "stu-k" "iknox-fa" "versusfacit" "mcknight-42" "jtcohen6" "aranke" "mikealfare" "dependabot[bot]" "snyk-bot" "colin-rogers-dbt" }}
+  {{- $core_team := list "michelleark" "peterallenwebb" "emmyoop" "nathaniel-may" "gshank" "leahwicz" "chenyulinx" "stu-k" "iknox-fa" "versusfacit" "mcknight-42" "jtcohen6" "aranke" "dependabot[bot]" "snyk-bot" "colin-rogers-dbt" }}
   {{- range $change := .Changes }}
     {{- $authorList := splitList " " $change.Custom.Author }}
-    {{- /* loop through all authors for a PR */}}
+    {{- /* loop through all authors for a single changelog */}}
     {{- range $author := $authorList }}
       {{- $authorLower := lower $author }}
       {{- /* we only want to include non-core team contributors */}}
       {{- if not (has $authorLower $core_team)}}
-        {{- $pr := $change.Custom.PR }}
-        {{- /* check if this contributor has other PRs associated with them already */}}
-        {{- if hasKey $contributorDict $author }}
-          {{- $prList := get $contributorDict $author }}
-          {{- $prList = append $prList $pr  }}
-          {{- $contributorDict := set $contributorDict $author $prList }}
-        {{- else }}
-          {{- $prList := list $change.Custom.PR }}
-          {{- $contributorDict := set $contributorDict $author $prList }}
-        {{- end }}
-      {{- end}}
+        {{- $changeList := splitList " " $change.Custom.Author }}
+          {{- $changeLink := $change.Kind }}
+          {{- if or (eq $change.Kind "Dependencies") (eq $change.Kind "Security") }}
+            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-redshift/pull/nbr)" | replace "nbr" $change.Custom.PR }}
+          {{- else }}
+            {{- $changeLink = "[#nbr](https://github.com/dbt-labs/dbt-redshift/issues/nbr)" | replace "nbr" $change.Custom.Issue }}
+          {{- end }}
+          {{- /* check if this contributor has other changes associated with them already */}}
+          {{- if hasKey $contributorDict $author }}
+            {{- $contributionList := get $contributorDict $author }}
+            {{- $contributionList = append $contributionList $changeLink  }}
+            {{- $contributorDict := set $contributorDict $author $contributionList }}
+          {{- else }}
+            {{- $contributionList := list $changeLink }}
+            {{- $contributorDict := set $contributorDict $author $contributionList }}
+          {{- end }}
+        {{- end}}
     {{- end}}
   {{- end }}
   {{- /* no indentation here for formatting so the final markdown doesn't have unneeded indentations */}}
   {{- if $contributorDict}}
   ### Contributors
   {{- range $k,$v := $contributorDict }}
-  - [@{{$k}}](https://github.com/{{$k}}) ({{ range $index, $element := $v }}{{if $index}}, {{end}}[#{{$element}}](https://github.com/dbt-labs/dbt-redshift/pull/{{$element}}){{end}})
+  - [@{{$k}}](https://github.com/{{$k}}) ({{ range $index, $element := $v }}{{if $index}}, {{end}}{{$element}}{{end}})
   {{- end }}
   {{- end }}

--- a/.github/workflows/bot-changelog.yml
+++ b/.github/workflows/bot-changelog.yml
@@ -9,7 +9,6 @@
 # time: <current timestamp>
 # custom:
 #   Author: <PR User Login (generally the bot)>
-#   Issue: 4904
 #   PR: <PR number>
 #
 # **why?**
@@ -40,7 +39,7 @@ jobs:
       matrix:
         include:
           - label: "dependencies"
-            changie_kind: "Dependency"
+            changie_kind: "Dependencies"
           - label: "snyk"
             changie_kind: "Security"
     runs-on: ubuntu-latest
@@ -58,4 +57,4 @@ jobs:
         commit_message: "Add automated changelog yaml from template for bot PR"
         changie_kind: ${{ matrix.changie_kind }}
         label: ${{ matrix.label }}
-        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  Issue: 150\n  PR: ${{ github.event.pull_request.number }}\n"
+        custom_changelog_string: "custom:\n  Author: ${{ github.event.pull_request.user.login }}\n  PR: ${{ github.event.pull_request.number }}\n"


### PR DESCRIPTION
Backport #280 

Necessary to allow other back ports to work without conflicts. Since PR is no longer required on main, when a change is back ported it will not have the PR in the changelog yaml and will break changelog generation.