### PR TITLE
Cleanup main after cutting new 1.5.test branch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0b2
+current_version = 1.10.0a1
 parse = (?P<major>[\d]+) # major version number
 	\.(?P<minor>[\d]+) # minor version number
 	\.(?P<patch>[\d]+) # patch version number
@@ -10,7 +10,7 @@ parse = (?P<major>[\d]+) # major version number
 	( # optional nightly release indicator
 	\.(?P<nightly>dev[0-9]+) # ex: .dev02142023
 	)? # expected matches: `1.15.0`, `1.5.0a11`, `1.5.0a1.dev123`, `1.5.0.dev123457`, expected failures: `1`, `1.5`, `1.5.2-a1`, `text1.5.0`
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{prekind}{num}.{nightly}
 	{major}.{minor}.{patch}.{nightly}
 	{major}.{minor}.{patch}{prekind}{num}
@@ -21,7 +21,7 @@ tag = False
 [bumpversion:part:prekind]
 first_value = a
 optional_value = final
-values =
+values = 
 	a
 	b
 	rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 
 - Rename constraints_enabled to contract ([#330](https://github.com/dbt-labs/dbt-redshift/issues/330))
 
-
-
 ## dbt-redshift 1.5.0-b1 - February 22, 2023
 
 ### Features
@@ -37,3 +35,4 @@ For information on prior major and minor releases, see their changelogs:
 - [1.2](https://github.com/dbt-labs/dbt-redshift/blob/1.2.latest/CHANGELOG.md)
 - [1.1](https://github.com/dbt-labs/dbt-redshift/blob/1.1.latest/CHANGELOG.md)
 - [1.0](https://github.com/dbt-labs/dbt-redshift/blob/1.0.latest/CHANGELOG.md)
+

--- a/dbt/adapters/redshift/__version__.py
+++ b/dbt/adapters/redshift/__version__.py
@@ -1,1 +1,1 @@
-version = "1.5.0b2"
+version = "1.10.0a1"


### PR DESCRIPTION
This PR will fail CI until the dbt-core PR has been merged due to release version conflicts.  dev-requirements.txt needs to be updated to have the dbt-core dependencies point to this new branch. The workflow that generated this PR also created a new branch: 1.5.test