### PR TITLE
ADAP-366: View Rerun Bug

### DIFF
--- a/.changes/unreleased/Fixes-20230316-132120.yaml
+++ b/.changes/unreleased/Fixes-20230316-132120.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Added methods to `RedshiftAdapter` that were inadvertantly dropped when migrating
+  from `PostgresAdapter` to `SQLAdapter`
+time: 2023-03-16T13:21:20.306393-04:00
+custom:
+  Author: mikealfare
+  Issue: "365"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -188,13 +188,7 @@ class RedshiftConnectionManager(SQLConnectionManager):
             yield
         except redshift_connector.DatabaseError as e:
             logger.debug(f"Redshift error: {str(e)}")
-
-            try:
-                self.rollback_if_open()
-            except Exception:
-                logger.debug("Failed to release connection!")
-                pass
-
+            self.rollback_if_open()
             raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
 
         except Exception as e:

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -1,26 +1,25 @@
 import re
 from multiprocessing import Lock
 from contextlib import contextmanager
-from typing import NewType, Tuple, Union
+from typing import NewType, Tuple, Union, Optional, List
+from dataclasses import dataclass, field
 
 import agate
 import sqlparse
+import redshift_connector
+from redshift_connector.utils.oids import get_datatype_name
+
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterResponse, Connection, Credentials
 from dbt.events import AdapterLogger
 import dbt.exceptions
 import dbt.flags
-import redshift_connector
 from dbt.dataclass_schema import FieldEncoder, dbtClassMixin, StrEnum
-
-from dataclasses import dataclass, field
-from typing import Optional, List
-
 from dbt.helper_types import Port
-from redshift_connector import OperationalError, DatabaseError, DataError
-from redshift_connector.utils.oids import get_datatype_name
+
 
 logger = AdapterLogger("Redshift")
+
 
 drop_lock: Lock = dbt.flags.MP_CONTEXT.Lock()  # type: ignore
 
@@ -69,7 +68,17 @@ class RedshiftCredentials(Credentials):
         return "redshift"
 
     def _connection_keys(self):
-        return "host", "port", "user", "database", "schema", "method", "cluster_id", "iam_profile"
+        return (
+            "host",
+            "port",
+            "user",
+            "database",
+            "schema",
+            "method",
+            "cluster_id",
+            "iam_profile",
+            "sslmode",
+        )
 
     @property
     def unique_field(self) -> str:
@@ -114,8 +123,6 @@ class RedshiftConnectMethodFactory:
                     c.cursor().execute("set role {}".format(self.credentials.role))
                 return c
 
-            return connect
-
         elif method == RedshiftConnectionMethod.IAM:
             if not self.credentials.cluster_id and "serverless" not in self.credentials.host:
                 raise dbt.exceptions.FailedToConnectError(
@@ -138,11 +145,12 @@ class RedshiftConnectMethodFactory:
                     c.cursor().execute("set role {}".format(self.credentials.role))
                 return c
 
-            return connect
         else:
             raise dbt.exceptions.FailedToConnectError(
                 "Invalid 'method' in profile: '{}'".format(method)
             )
+
+        return connect
 
 
 class RedshiftConnectionManager(SQLConnectionManager):
@@ -155,18 +163,18 @@ class RedshiftConnectionManager(SQLConnectionManager):
         return res
 
     def cancel(self, connection: Connection):
-        connection_name = connection.name
         try:
             pid = self._get_backend_pid()
-            sql = "select pg_terminate_backend({})".format(pid)
-            _, cursor = self.add_query(sql)
-            res = cursor.fetchone()
-            logger.debug("Cancel query '{}': {}".format(connection_name, res))
-        except redshift_connector.error.InterfaceError as e:
+        except redshift_connector.InterfaceError as e:
             if "is closed" in str(e):
-                logger.debug(f"Connection {connection_name} was already closed")
+                logger.debug(f"Connection {connection.name} was already closed")
                 return
             raise
+
+        sql = f"select pg_terminate_backend({pid})"
+        _, cursor = self.add_query(sql)
+        res = cursor.fetchone()
+        logger.debug(f"Cancel query '{connection.name}': {res}")
 
     @classmethod
     def get_response(cls, cursor: redshift_connector.Cursor) -> AdapterResponse:
@@ -178,29 +186,33 @@ class RedshiftConnectionManager(SQLConnectionManager):
     def exception_handler(self, sql):
         try:
             yield
-        except redshift_connector.error.DatabaseError as e:
+        except redshift_connector.DatabaseError as e:
             logger.debug(f"Redshift error: {str(e)}")
-            self.rollback_if_open()
-            raise dbt.exceptions.DbtDatabaseError(str(e))
+
+            try:
+                self.rollback_if_open()
+            except Exception:
+                logger.debug("Failed to release connection!")
+                pass
+
+            raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
+
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
             self.rollback_if_open()
             # Raise DBT native exceptions as is.
-            if isinstance(e, dbt.exceptions.Exception):
+            if isinstance(e, dbt.exceptions.DbtRuntimeError):
                 raise
             raise dbt.exceptions.DbtRuntimeError(str(e)) from e
 
     @contextmanager
-    def fresh_transaction(self, name=None):
+    def fresh_transaction(self):
         """On entrance to this context manager, hold an exclusive lock and
         create a fresh transaction for redshift, then commit and begin a new
         one before releasing the lock on exit.
 
         See drop_relation in RedshiftAdapter for more information.
-
-        :param Optional[str] name: The name of the connection to use, or None
-            to use the default.
         """
         with drop_lock:
             connection = self.get_thread_connection()
@@ -210,8 +222,8 @@ class RedshiftConnectionManager(SQLConnectionManager):
 
             self.begin()
             yield
-
             self.commit()
+
             self.begin()
 
     @classmethod
@@ -226,7 +238,11 @@ class RedshiftConnectionManager(SQLConnectionManager):
         def exponential_backoff(attempt: int):
             return attempt * attempt
 
-        retryable_exceptions = [OperationalError, DatabaseError, DataError]
+        retryable_exceptions = [
+            redshift_connector.OperationalError,
+            redshift_connector.DatabaseError,
+            redshift_connector.DataError,
+        ]
 
         return cls.retry_connection(
             connection,

--- a/dbt/include/redshift/macros/relations.sql
+++ b/dbt/include/redshift/macros/relations.sql
@@ -1,3 +1,3 @@
 {% macro redshift__get_relations () -%}
-  {{ return(dbt.postgres__get_relations()) }}
+  {{ return(dbt.postgres_get_relations()) }}
 {% endmacro %}

--- a/tests/functional/adapter/backup_tests/models.py
+++ b/tests/functional/adapter/backup_tests/models.py
@@ -1,0 +1,61 @@
+BACKUP_IS_FALSE = """
+{{ config(
+    materialized='table',
+    backup=False
+) }}
+select 1 as my_col
+"""
+
+
+BACKUP_IS_TRUE = """
+{{ config(
+    materialized='table',
+    backup=True
+) }}
+select 1 as my_col
+"""
+
+
+BACKUP_IS_UNDEFINED = """
+{{ config(
+    materialized='table'
+) }}
+select 1 as my_col
+"""
+
+
+BACKUP_IS_TRUE_VIEW = """
+{{ config(
+    materialized='view',
+    backup=True
+) }}
+select 1 as my_col
+"""
+
+
+SYNTAX_WITH_DISTKEY = """
+{{ config(
+    materialized='table',
+    backup=False,
+    dist='my_col'
+) }}
+select 1 as my_col
+"""
+
+
+SYNTAX_WITH_SORTKEY = """
+{{ config(
+    materialized='table',
+    backup=False,
+    sort='my_col'
+) }}
+select 1 as my_col
+"""
+
+
+BACKUP_IS_UNDEFINED_DEPENDENT_VIEW = """
+{{ config(
+    materialized='view',
+) }}
+select * from {{ ref('backup_is_undefined') }}
+"""

--- a/tests/functional/adapter/backup_tests/test_backup_table.py
+++ b/tests/functional/adapter/backup_tests/test_backup_table.py
@@ -2,7 +2,7 @@ import pytest
 
 from dbt.tests.util import run_dbt
 
-from functional.adapter.backup_tests import models
+from tests.functional.adapter.backup_tests import models
 
 
 class BackupTableBase:

--- a/tests/functional/adapter/backup_tests/test_backup_table.py
+++ b/tests/functional/adapter/backup_tests/test_backup_table.py
@@ -2,60 +2,7 @@ import pytest
 
 from dbt.tests.util import run_dbt
 
-
-_MODEL_BACKUP_IS_FALSE = """
-{{ config(
-    materialized='table',
-    backup=False
-) }}
-select 1 as my_col
-"""
-
-
-_MODEL_BACKUP_IS_TRUE = """
-{{ config(
-    materialized='table',
-    backup=True
-) }}
-select 1 as my_col
-"""
-
-
-_MODEL_IS_UNDEFINED = """
-{{ config(
-    materialized='table'
-) }}
-select 1 as my_col
-"""
-
-
-_MODEL_IS_TRUE_VIEW = """
-{{ config(
-    materialized='view',
-    backup=True
-) }}
-select 1 as my_col
-"""
-
-
-_MODEL_SYNTAX_WITH_DISTKEY = """
-{{ config(
-    materialized='table',
-    backup=False,
-    dist='my_col'
-) }}
-select 1 as my_col
-"""
-
-
-_MODEL_SYNTAX_WITH_SORTKEY = """
-{{ config(
-    materialized='table',
-    backup=False,
-    sort='my_col'
-) }}
-select 1 as my_col
-"""
+from functional.adapter.backup_tests import models
 
 
 class BackupTableBase:
@@ -68,10 +15,10 @@ class TestBackupTableOption(BackupTableBase):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "backup_is_false.sql": _MODEL_BACKUP_IS_FALSE,
-            "backup_is_true.sql": _MODEL_BACKUP_IS_TRUE,
-            "backup_is_undefined.sql": _MODEL_IS_UNDEFINED,
-            "backup_is_true_view.sql": _MODEL_IS_TRUE_VIEW,
+            "backup_is_false.sql": models.BACKUP_IS_FALSE,
+            "backup_is_true.sql": models.BACKUP_IS_TRUE,
+            "backup_is_undefined.sql": models.BACKUP_IS_UNDEFINED,
+            "backup_is_true_view.sql": models.BACKUP_IS_TRUE_VIEW,
         }
 
     @pytest.mark.parametrize(
@@ -103,8 +50,8 @@ class TestBackupTableSyntax(BackupTableBase):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "syntax_with_distkey.sql": _MODEL_SYNTAX_WITH_DISTKEY,
-            "syntax_with_sortkey.sql": _MODEL_SYNTAX_WITH_SORTKEY,
+            "syntax_with_distkey.sql": models.SYNTAX_WITH_DISTKEY,
+            "syntax_with_sortkey.sql": models.SYNTAX_WITH_SORTKEY,
         }
 
     @pytest.mark.parametrize(
@@ -137,8 +84,8 @@ class TestBackupTableProjectDefault(BackupTableBase):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "backup_is_true.sql": _MODEL_BACKUP_IS_TRUE,
-            "backup_is_undefined.sql": _MODEL_IS_UNDEFINED,
+            "backup_is_true.sql": models.BACKUP_IS_TRUE,
+            "backup_is_undefined.sql": models.BACKUP_IS_UNDEFINED,
         }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
resolves #365

### Description

- Update `RedshiftAdapter` to include link_cache_relation methods that were inadvertently dropped when migrating from inheriting from `PostgresAdapter` to inheriting directly from `SQLAdapter`
- Add test case to catch this error in the future

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
