### PR TITLE
Fix for #419: dbt-redshift 1.5 does not work with non-standard redshift hostnames

### DIFF
--- a/.changes/unreleased/Fixes-20230428-142321.yaml
+++ b/.changes/unreleased/Fixes-20230428-142321.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Adding region as independent param in profiles
+time: 2023-04-28T14:23:21.041865-07:00
+custom:
+  Author: nssalian
+  Issue: "419"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -86,7 +86,6 @@ class RedshiftCredentials(Credentials):
         return self.host
 
 
-# TODO: Move this to the redshift connector
 def _get_aws_regions():
     url = "https://ip-ranges.amazonaws.com/ip-ranges.json"
     response = urllib.request.urlopen(url)
@@ -126,7 +125,8 @@ class RedshiftConnectMethodFactory:
                 region_value = self.credentials.host.split(".")[2]
             except IndexError:
                 raise dbt.exceptions.FailedToConnectError(
-                    "Unable to determine region from host: " "{}".format(self.credentials.host)
+                    "No region provided and unable to determine region from host: "
+                    "{}".format(self.credentials.host)
                 )
 
             kwargs["region"] = region_value
@@ -134,7 +134,7 @@ class RedshiftConnectMethodFactory:
         # Validate the set region
         if not kwargs["region"] in _AVAILABLE_AWS_REGIONS:
             raise dbt.exceptions.FailedToConnectError(
-                "Invalid region provided: " "{}".format(kwargs["region"])
+                "Invalid region provided: {}".format(kwargs["region"])
             )
 
         if self.credentials.sslmode:

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -102,6 +102,13 @@ def _get_aws_regions():
 _AVAILABLE_AWS_REGIONS = _get_aws_regions()
 
 
+def _is_valid_region(region):
+    if region is None or len(region) == 0:
+        logger.warning("Couldn't determine AWS regions. Skipping validation to avoid blocking.")
+        return True
+    return region in _AVAILABLE_AWS_REGIONS
+
+
 class RedshiftConnectMethodFactory:
     credentials: RedshiftCredentials
 
@@ -132,7 +139,7 @@ class RedshiftConnectMethodFactory:
             kwargs["region"] = region_value
 
         # Validate the set region
-        if not kwargs["region"] in _AVAILABLE_AWS_REGIONS:
+        if not _is_valid_region(kwargs["region"]):
             raise dbt.exceptions.FailedToConnectError(
                 "Invalid region provided: {}".format(kwargs["region"])
             )

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -106,7 +106,6 @@ class RedshiftConnectMethodFactory:
     def __init__(self, credentials):
         self.credentials = credentials
         self.valid_aws_regions = _get_aws_regions()
-        print("Valid AWS regions: {}".format(self.valid_aws_regions))
 
     def _is_valid_region(self, region_value):
         return region_value in self.valid_aws_regions
@@ -131,11 +130,13 @@ class RedshiftConnectMethodFactory:
                     "Unable to determine region from host: " "{}".format(self.credentials.host)
                 )
 
-            if not self._is_valid_region(region_value):
-                raise dbt.exceptions.FailedToConnectError(
-                    "Invalid region provided: " "{}".format(region_value)
-                )
             kwargs["region"] = region_value
+
+        # Validate the set region
+        if not self._is_valid_region(region_value=kwargs["region"]):
+            raise dbt.exceptions.FailedToConnectError(
+                "Invalid region provided: " "{}".format(kwargs["region"])
+            )
 
         if self.credentials.sslmode:
             kwargs["sslmode"] = self.credentials.sslmode

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -35,6 +35,23 @@ class IAMDurationEncoder(FieldEncoder):
 dbtClassMixin.register_field_encoders({IAMDuration: IAMDurationEncoder()})
 
 
+def _get_aws_regions():
+    # Extract the prefixes from the AWS IP ranges JSON to determine the available regions
+    url = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+    response = urllib.request.urlopen(url)
+    data = json.loads(response.read().decode())
+    regions = set()
+
+    for prefix in data["prefixes"]:
+        if prefix["service"] == "AMAZON":
+            regions.add(prefix["region"])
+
+    return regions
+
+
+_AVAILABLE_AWS_REGIONS = _get_aws_regions()
+
+
 class RedshiftConnectionMethod(StrEnum):
     DATABASE = "database"
     IAM = "iam"
@@ -84,22 +101,6 @@ class RedshiftCredentials(Credentials):
     @property
     def unique_field(self) -> str:
         return self.host
-
-
-def _get_aws_regions():
-    url = "https://ip-ranges.amazonaws.com/ip-ranges.json"
-    response = urllib.request.urlopen(url)
-    data = json.loads(response.read().decode())
-    regions = set()
-
-    for prefix in data["prefixes"]:
-        if prefix["service"] == "AMAZON":
-            regions.add(prefix["region"])
-
-    return regions
-
-
-_AVAILABLE_AWS_REGIONS = _get_aws_regions()
 
 
 def _is_valid_region(region):

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -100,15 +100,14 @@ def _get_aws_regions():
     return regions
 
 
+_AVAILABLE_AWS_REGIONS = _get_aws_regions()
+
+
 class RedshiftConnectMethodFactory:
     credentials: RedshiftCredentials
 
     def __init__(self, credentials):
         self.credentials = credentials
-        self.valid_aws_regions = _get_aws_regions()
-
-    def _is_valid_region(self, region_value):
-        return region_value in self.valid_aws_regions
 
     def get_connect_method(self):
         method = self.credentials.method
@@ -133,7 +132,7 @@ class RedshiftConnectMethodFactory:
             kwargs["region"] = region_value
 
         # Validate the set region
-        if not self._is_valid_region(region_value=kwargs["region"]):
+        if not kwargs["region"] in _AVAILABLE_AWS_REGIONS:
             raise dbt.exceptions.FailedToConnectError(
                 "Invalid region provided: " "{}".format(kwargs["region"])
             )

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -180,7 +180,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             method="iam",
             iam_profile="test",
             host="doesnotexist.1233.redshift-serverless.amazonaws.com",
-            region="us-east-3",
+            region="us-east-2",
         )
         connection = self.adapter.acquire_connection("dummy")
         connection.handle
@@ -189,7 +189,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             host="doesnotexist.1233.redshift-serverless.amazonaws.com",
             database="redshift",
             cluster_identifier=None,
-            region="us-east-3",
+            region="us-east-2",
             auto_create=False,
             db_groups=[],
             db_user="root",

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -176,6 +176,7 @@ class TestRedshiftAdapter(unittest.TestCase):
     @mock.patch("redshift_connector.connect", Mock())
     @mock.patch("boto3.Session", Mock())
     def test_explicit_region(self):
+        # Successful test
         self.config.credentials = self.config.credentials.replace(
             method="iam",
             iam_profile="test",
@@ -203,7 +204,7 @@ class TestRedshiftAdapter(unittest.TestCase):
     @mock.patch("redshift_connector.connect", Mock())
     @mock.patch("boto3.Session", Mock())
     def test_explicit_region_failure(self):
-        # Failure cases
+        # Failure test with no region
         self.config.credentials = self.config.credentials.replace(
             method="iam",
             iam_profile="test",
@@ -232,7 +233,7 @@ class TestRedshiftAdapter(unittest.TestCase):
     @mock.patch("redshift_connector.connect", Mock())
     @mock.patch("boto3.Session", Mock())
     def test_explicit_invalid_region(self):
-        # Failure cases
+        # Invalid region test
         self.config.credentials = self.config.credentials.replace(
             method="iam",
             iam_profile="test",


### PR DESCRIPTION
resolves #419 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

Added region as a field and remove the host parsing hard-coding

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
