### PR TITLE
Fix execute signature based on core

### DIFF
--- a/.changes/unreleased/Fixes-20230509-143721.yaml
+++ b/.changes/unreleased/Fixes-20230509-143721.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Update signature for execute method
+time: 2023-05-09T14:37:21.163869-07:00
+custom:
+  Author: nssalian
+  Issue: ''' '''

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -299,12 +299,16 @@ class RedshiftConnectionManager(SQLConnectionManager):
         )
 
     def execute(
-        self, sql: str, auto_begin: bool = False, fetch: bool = False
+        self,
+        sql: str,
+        auto_begin: bool = False,
+        fetch: bool = False,
+        limit: Optional[int] = None,
     ) -> Tuple[AdapterResponse, agate.Table]:
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:
-            table = self.get_result_from_cursor(cursor)
+            table = self.get_result_from_cursor(cursor, limit)
         else:
             table = dbt.clients.agate_helper.empty_table()
         return response, table

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -408,7 +408,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                     mock_get_result_from_cursor.return_value = table
                     self.adapter.connections.execute(sql="select * from test", fetch=True)
         mock_add_query.assert_called_once_with("select * from test", False)
-        mock_get_result_from_cursor.assert_called_once_with(cursor)
+        mock_get_result_from_cursor.assert_called_once_with(cursor, None)
         mock_get_response.assert_called_once_with(cursor)
 
     def test_execute_without_fetch(self):


### PR DESCRIPTION
fixes the signature change in `execute` from `dbt-core` here: https://github.com/dbt-labs/dbt-core/pull/7545

### Description



### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
