### PR TITLE
Add autocommit feature to let dbt users run certain db commands in macros

### DIFF
--- a/.changes/unreleased/Fixes-20230520-043039.yaml
+++ b/.changes/unreleased/Fixes-20230520-043039.yaml
@@ -3,4 +3,4 @@ body: Add a new connection param to reenable certain Redshift commands in macros
 time: 2023-05-20T04:30:39.358755-07:00
 custom:
   Author: versusfacit
-  Issue: "425"
+  Issue: "463"

--- a/.changes/unreleased/Fixes-20230520-043039.yaml
+++ b/.changes/unreleased/Fixes-20230520-043039.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add a new connection param to reenable certain Redshift commands in macros.
+time: 2023-05-20T04:30:39.358755-07:00
+custom:
+  Author: versusfacit
+  Issue: "425"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -77,6 +77,7 @@ class RedshiftCredentials(Credentials):
     sslmode: Optional[str] = None
     retries: int = 1
     region: Optional[str] = None  # if not provided, will be determined from host
+    autocommit: Optional[bool] = False
 
     _ALIASES = {"dbname": "database", "pass": "password"}
 
@@ -164,6 +165,8 @@ class RedshiftConnectMethodFactory:
                     password=self.credentials.password,
                     **kwargs,
                 )
+                if self.credentials.autocommit:
+                    c.autocommit = True
                 if self.credentials.role:
                     c.cursor().execute("set role {}".format(self.credentials.role))
                 return c
@@ -186,6 +189,8 @@ class RedshiftConnectMethodFactory:
                     profile=self.credentials.iam_profile,
                     **kwargs,
                 )
+                if self.credentials.autocommit:
+                    c.autocommit = True
                 if self.credentials.role:
                     c.cursor().execute("set role {}".format(self.credentials.role))
                 return c

--- a/tests/functional/adapter/test_autocommit.py
+++ b/tests/functional/adapter/test_autocommit.py
@@ -31,13 +31,14 @@ class TestAutocommitWorksWithTransactionBlocks:
     @pytest.fixture(scope="class")
     def dbt_profile_target(self):
         return {
-            "type": "postgres",
-            "threads": 4,
-            "host": "localhost",
-            "port": int(os.getenv("POSTGRES_TEST_PORT", 5432)),
-            "user": os.getenv("POSTGRES_TEST_USER", "root"),
-            "pass": os.getenv("POSTGRES_TEST_PASS", "password"),
-            "dbname": os.getenv("POSTGRES_TEST_DATABASE", "dbt"),
+            "type": "redshift",
+            "threads": 1,
+            "retries": 6,
+            "host": os.getenv("REDSHIFT_TEST_HOST"),
+            "port": int(os.getenv("REDSHIFT_TEST_PORT")),
+            "user": os.getenv("REDSHIFT_TEST_USER"),
+            "pass": os.getenv("REDSHIFT_TEST_PASS"),
+            "dbname": os.getenv("REDSHIFT_TEST_DBNAME"),
             "autocommit": True,
         }
 

--- a/tests/functional/adapter/test_autocommit.py
+++ b/tests/functional/adapter/test_autocommit.py
@@ -55,6 +55,6 @@ class TestTransactionBlocksPreventCertainCommands:
         return {"macro.sql": _MACROS__CREATE_DB}
 
     def test_normally_create_db_disallowed(self, project):
-        """Monitor if status quo in Cedshift connector changes"""
+        """Monitor if status quo in Redshift connector changes"""
         result, out = run_dbt_and_capture(["run-operation", "create_db_fake"], expect_pass=False)
         assert "CREATE DATABASE cannot run inside a transaction block" in out

--- a/tests/functional/adapter/test_autocommit.py
+++ b/tests/functional/adapter/test_autocommit.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+
+from dbt.tests.util import run_dbt_and_capture
+
+_MACROS__CREATE_DB = """
+{% macro create_db_fake() %}
+
+{% set database = "db_for_test__do_delete_if_you_see_this" %}
+
+{# IF NOT EXISTS not avaiable but Redshift merely returns an error for trying to overwrite #}
+{% set create_command %}
+    CREATE DATABASE {{ database }}
+{% endset %}
+
+{{ log(create_command, info=True) }}
+
+{% do run_query(create_command) %}
+
+{{ log("Created redshift database " ~ database, info=True) }}
+
+{% endmacro %}
+"""
+
+
+class TestAutocommitWorksWithTransactionBlocks:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"macro.sql": _MACROS__CREATE_DB}
+
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "postgres",
+            "threads": 4,
+            "host": "localhost",
+            "port": int(os.getenv("POSTGRES_TEST_PORT", 5432)),
+            "user": os.getenv("POSTGRES_TEST_USER", "root"),
+            "pass": os.getenv("POSTGRES_TEST_PASS", "password"),
+            "dbname": os.getenv("POSTGRES_TEST_DATABASE", "dbt"),
+            "autocommit": True,
+        }
+
+    def test_autocommit_allows_for_more_commands(self, project):
+        """Scenario: user has autocommit=True in their target to run macros with normally
+        forbidden commands like CREATE DATABASE and VACUUM"""
+        result, out = run_dbt_and_capture(["run-operation", "create_db_fake"], expect_pass=False)
+        assert "CREATE DATABASE cannot run inside a transaction block" not in out
+
+
+class TestTransactionBlocksPreventCertainCommands:
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"macro.sql": _MACROS__CREATE_DB}
+
+    def test_normally_create_db_disallowed(self, project):
+        """Monitor if status quo in Cedshift connector changes"""
+        result, out = run_dbt_and_capture(["run-operation", "create_db_fake"], expect_pass=False)
+        assert "CREATE DATABASE cannot run inside a transaction block" in out


### PR DESCRIPTION
resolves #463 

An imperfect but what I think is a necessary solution to unblock users from #425 

## Description of solution

Root cause: Connection objects used in Python must have [`autocommit = True`](https://docs.aws.amazon.com/redshift/latest/mgmt/python-connect-examples.html) to run `CREATE DATABASE`, `VACUUM`, etc..

But, this is a Python-level thing we need to alter. The docs I linked above have this snippet.

<img width="505" alt="image" src="https://github.com/dbt-labs/dbt-redshift/assets/67295367/9aa34c4e-9428-49fc-8eb0-d422ec568701">

Yep, this is official guidance. So, we have to alter the connection in the Python post hoc instead of altering the connection instantiation function.

All together -- if we make it an opt-in config for users, we could direct them to define a separate target with `autocommit=True`. This isn't great but it was straightforward enough for me to get 1.5 users unblocked within the sprint!

### Pros of this solution

Let users configure this behavior on their connection profiles. 
* no need for a massive threading rewrite which would be way out of scope of the issue (unblocking users faster)
* finessed opt-in despite the code being kind of blunt ("do this on all connections")
* let users configure on the profile (no env var memorization required for CLI)

------

## The Alternatives Turned Down
1. **Forbid users entirely from using these commands**. Disservice to the user as they worked fine prior to 1.5
2. **Stop using the Redshift connector**. Goes way against our current partner/design philosophy
3. **Enable autocommit for all connections**. Not a great idea: Doing so invites performance hits, data inconsistency faults, no ACID across multiple statements, etc. 
4. **Have dbt silently flip this option on or off for these commands**. My original hope unrealized; requires rewrite of connection contexts.
5. **Okay, then fine. Let's rewrite our connection context code to alter connections based on whatever SQL they're running.** There is no easy way to alter a thread based on what SQL is handed it (thanks Gerda for corroborating that 🙏 ). Neither is this the case for core nor Redshift.

----

## Fix/feature add screenshots to illustrate impact

With this option `autocommit: False` in profile:

<img width="1330" alt="image" src="https://github.com/dbt-labs/dbt-redshift/assets/67295367/d779e73c-a77a-463c-a093-b2dd1d07fbf5">

With this option `autocommit: True` in profile:

<img width="1330" alt="image" src="https://github.com/dbt-labs/dbt-redshift/assets/67295367/5abe08de-20a1-44c3-aab1-bd2db1478b8e">

## How to use this

### 1
Define all macros in a folder with the "autocommit enabled" target
<img width="671" alt="image" src="https://github.com/dbt-labs/dbt-redshift/assets/67295367/0e72708d-577f-495d-88ed-379538151f73">


### 2
Swap the target on the command line: `--profile TEXT # Which profile to load`. This method is useful for adhoc/scheduled Cloud jobs 💃 


### Followup

1.5 Backport

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
