### PR TITLE
[Backport] 433

### DIFF
--- a/.changes/unreleased/Fixes-20230508-094834.yaml
+++ b/.changes/unreleased/Fixes-20230508-094834.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix redshift_connector issue of timing out after 30s
+time: 2023-05-08T09:48:34.019843-07:00
+custom:
+  Author: jiezhen-chen
+  Issue: "427"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -72,7 +72,7 @@ class RedshiftCredentials(Credentials):
     autocreate: bool = False
     db_groups: List[str] = field(default_factory=list)
     ra3_node: Optional[bool] = False
-    connect_timeout: int = 30
+    connect_timeout: Optional[int] = None
     role: Optional[str] = None
     sslmode: Optional[str] = None
     retries: int = 1
@@ -304,12 +304,12 @@ class RedshiftConnectionManager(SQLConnectionManager):
         )
 
     def execute(
-        self, sql: str, auto_begin: bool = False, fetch: bool = False
+        self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: Optional[int] = None
     ) -> Tuple[AdapterResponse, agate.Table]:
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:
-            table = self.get_result_from_cursor(cursor)
+            table = self.get_result_from_cursor(cursor, limit)
         else:
             table = dbt.clients.agate_helper.empty_table()
         return response, table

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -304,12 +304,12 @@ class RedshiftConnectionManager(SQLConnectionManager):
         )
 
     def execute(
-        self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: Optional[int] = None
+        self, sql: str, auto_begin: bool = False, fetch: bool = False
     ) -> Tuple[AdapterResponse, agate.Table]:
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:
-            table = self.get_result_from_cursor(cursor, limit)
+            table = self.get_result_from_cursor(cursor)
         else:
             table = dbt.clients.agate_helper.empty_table()
         return response, table

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -72,7 +72,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
+            timeout=None,
             region="us-east-1",
         )
 
@@ -91,7 +91,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             auto_create=False,
             db_groups=[],
             region="us-east-1",
-            timeout=30,
+            timeout=None,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -115,8 +115,25 @@ class TestRedshiftAdapter(unittest.TestCase):
             auto_create=False,
             db_groups=[],
             profile=None,
-            timeout=30,
+            timeout=None,
             port=5439,
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
+    def test_conn_timeout_30(self):
+        self.config.credentials = self.config.credentials.replace(connect_timeout=30)
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            region="us-east-1",
+            timeout=30,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -143,7 +160,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password="",
             user="",
             profile="test",
-            timeout=30,
+            timeout=None,
             port=5439,
         )
 
@@ -169,7 +186,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password="",
             user="",
             profile="test",
-            timeout=30,
+            timeout=None,
             port=5439,
         )
 
@@ -197,7 +214,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             password="",
             user="",
             profile="test",
-            timeout=30,
+            timeout=None,
             port=5439,
         )
 
@@ -226,7 +243,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 password="",
                 user="",
                 profile="test",
-                timeout=30,
+                timeout=None,
                 port=5439,
             )
 
@@ -255,7 +272,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 password="",
                 user="",
                 profile="test",
-                timeout=30,
+                timeout=None,
                 port=5439,
             )
 
@@ -283,7 +300,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 user="",
                 profile="test",
                 port=5439,
-                timeout=30,
+                timeout=None,
             )
         self.assertTrue("'host' must be provided" in context.exception.msg)
 


### PR DESCRIPTION
resolves #433 backport to 1.5.latest

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Example:
    resolves #1234
-->

### Description

changes connect_timeout default to None optional which is same as redshift_connector
noticed some small changes in main and wanted to make sure this older work also doesn't needed to be backported: https://github.com/dbt-labs/dbt-redshift/commit/52a666eaf1592e6bf87a01501a1fa444c1cd2a52

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
