### PR TITLE
Escape `%` symbols in table/view/column comments

### DIFF
--- a/.changes/unreleased/Fixes-20230524-151825.yaml
+++ b/.changes/unreleased/Fixes-20230524-151825.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Escape `%` symbols in table/view/column comments
+time: 2023-05-24T15:18:25.834088-06:00
+custom:
+  Author: dbeatty10
+  Issue: "441"

--- a/dbt/include/redshift/macros/adapters.sql
+++ b/dbt/include/redshift/macros/adapters.sql
@@ -292,3 +292,21 @@
   {% endif %}
 
 {% endmacro %}
+
+{#
+  By using dollar-quoting like this, users can embed anything they want into their comments
+  (including nested dollar-quoting), as long as they do not use this exact dollar-quoting
+  label. It would be nice to just pick a new one but eventually you do have to give up.
+#}
+{% macro postgres_escape_comment(comment) -%}
+  {% if comment is not string %}
+    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}
+  {% endif %}
+  {%- set magic = '$dbt_comment_literal_block$' -%}
+  {%- if magic in comment -%}
+    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}
+  {%- endif -%}
+  {#- -- escape % until the underlying issue is fixed in redshift_connector -#}
+  {%- set comment = comment|replace("%", "%%") -%}
+  {{ magic }}{{ comment }}{{ magic }}
+{%- endmacro %}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,9 @@
 # install latest changes in dbt-core + dbt-postgres
 # TODO: how to switch from HEAD to x.y.latest branches after minor releases?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
+
+git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-postgres&subdirectory=plugins/postgres
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,8 @@
 # install latest changes in dbt-core + dbt-postgres
 # TODO: how to switch from HEAD to x.y.latest branches after minor releases?
-
-git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-tests-adapter&subdirectory=tests/adapter
-git+https://github.com/dbt-labs/dbt-core.git@dbeatty/comments-with-percent-symbol#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor


### PR DESCRIPTION
resolves #441

### Description

I suspect there's a bug that affects `redshift_connector` (and possibly `pg8000` too) where a [comment](https://docs.aws.amazon.com/redshift/latest/dg/r_COMMENT.html) like the following raises an error regardless if using `paramstyle = 'pyformat'` or `paramstyle = 'format'`:
```sql
  comment on table customers is '95% of customer records';
```

To solve, I took the implementation of `postgres_escape_comment` from https://github.com/dbt-labs/dbt-core/pull/2378 and tweaked it slightly in order to escape all `%` symbols to be `%%` instead.

Added text containing `%` to the functional tests within dbt-core so that we can cover this test case in dbt-redshift and other adapters.

### Checklists

#### Upon opening
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)

#### Before merging
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests
- [x] Docs changes are not required/relevant for this PR
- [x] Revert changes to `dev-requirements.txt` in https://github.com/dbt-labs/dbt-redshift/pull/466/commits/1b41d8c479004194da7eb29ced98577c80f24d0a