### PR TITLE
Use smaller batch size for seeds

### DIFF
--- a/.changes/unreleased/Fixes-20230524-165236.yaml
+++ b/.changes/unreleased/Fixes-20230524-165236.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Use smaller default batch size for seeds
+time: 2023-05-24T16:52:36.915348-06:00
+custom:
+  Author: dbeatty10
+  Issue: "347"

--- a/dbt/include/redshift/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/redshift/macros/materializations/seeds/helpers.sql
@@ -1,0 +1,3 @@
+{% macro redshift__get_batch_size() %}
+  {{ return(500) }}
+{% endmacro %}


### PR DESCRIPTION
mitigates (but does not solve root cause of) #347

### Description

For seed CSV files above a certain size, the `redshift_connector` raises the following error:
```
'h' format requires -32768 <= number <= 32767`
```

To mitigate the effect on downstream users, we can lower the default batch size from `10000` to `500`.

In local performance testing using 1.4 (and `psychopg2`), a CSV with 6,000 rows took ~10 seconds to load batch sizes of `10000` to `500` (no difference).

Using 1.5 and (and `redshift_connector`), it took ~13 seconds using a batch size of `500` and ~23 seconds using a batch size of `50`.

### Proposal
My suggestion would be to use a batch size of `500` to mitigate the effect on downstream users while still pursuing a more satisfactory solution (which will probably require a change in `redshift_connector`).

In the meantime, if any users are still running into issues, they can lower their project-specific default even lower with the following file in their dbt project (adjusting the number lower as-needed):
`macros/get_batch_size.sql`
```
{% macro redshift__get_batch_size() %}
  {{ return(500) }}
{% endmacro %}
```

### Testing
I did not include any new CI tests since I was assuming we don't want to add large seed files to CI. This seems okay to me since this PR is not introducing any new behavior -- it is merely override the default batch size for seeds [here](https://github.com/dbt-labs/dbt-core/blob/7c1bd91d0ae3ecea12c7f755cd0b8bb44037f319/core/dbt/include/global_project/macros/materializations/seeds/helpers.sql#L71-L73).

However, I did verify the effect of this change locally.

### Checklist

#### Upon opening
- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)

#### Before merging
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I did not include any new CI tests since I was assuming we don't want to add large seed files to CI
- [x] Docs changes are not required/relevant for this PR
