### PR TITLE
ADAP-512: sslmode translation

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230522-111945.yaml
+++ b/.changes/unreleased/Breaking Changes-20230522-111945.yaml
@@ -1,0 +1,7 @@
+kind: Breaking Changes
+body: sslmode behavior has changed. To connect without ssl, set sslmode = disable.
+  To connect using ssl, set sslmode to verify-ca, or verify-full.
+time: 2023-05-22T11:19:45.927903-07:00
+custom:
+  Author: jiezhen-chen
+  Issue: "429"

--- a/.changes/unreleased/Fixes-20230512-082027.yaml
+++ b/.changes/unreleased/Fixes-20230512-082027.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: translate psycopg2 sslmode to ssl and sslmode in redshift_connector
+time: 2023-05-12T08:20:27.486301-07:00
+custom:
+  Author: jiezhen-chen
+  Issue: "429"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -112,32 +112,33 @@ def _is_valid_region(region):
 
 
 def _translate_sslmode(sslmode_input):
-    sslmode_input = sslmode_input.lower()
     args = {"ssl": True, "sslmode": "verify-ca"}
     warning_msg = (
         "Establishing connection using ssl with sslmode set to 'verify-ca'."
         "To connect without ssl, set sslmode to 'disable'."
     )
-    if sslmode_input == "disable":
-        args["ssl"] = False
-        args["sslmode"] = None
-        warning_msg = "Establishing connection without ssl."
-    elif (
-        sslmode_input == "verify-ca"
-        or sslmode_input == "verify-full"
-        or sslmode_input == "require"
-    ):
-        args["sslmode"] = sslmode_input
-        warning_msg = None
-    elif sslmode_input == "none":
-        args["sslmode"] = "verify-ca"
-    elif sslmode_input != "allow" and sslmode_input != "prefer":
-        args["sslmode"] = "verify-ca"
-        warning_msg = (
-            "Redshift adapter: Invalid sslmode provided. Establishing connection using ssl with "
-            "sslmode set to 'verify-ca'. Supported values are 'disable', 'allow', 'prefer', 'require', "
-            "'verify-ca', 'verify-full'."
-        )
+    if sslmode_input is not None:
+        sslmode_input = sslmode_input.lower()
+        if sslmode_input == "disable":
+            args["ssl"] = False
+            args["sslmode"] = None
+            warning_msg = "Establishing connection without ssl."
+        elif (
+            sslmode_input == "verify-ca"
+            or sslmode_input == "verify-full"
+            or sslmode_input == "require"
+        ):
+            args["sslmode"] = sslmode_input
+            warning_msg = None
+        elif sslmode_input == "none":
+            args["sslmode"] = "verify-ca"
+        elif sslmode_input != "allow" and sslmode_input != "prefer":
+            args["sslmode"] = "verify-ca"
+            warning_msg = (
+                "Redshift adapter: Invalid sslmode provided. Establishing connection using ssl with "
+                "sslmode set to 'verify-ca'. Supported values are 'disable', 'allow', 'prefer', 'require', "
+                "'verify-ca', 'verify-full'."
+            )
 
     return args, warning_msg
 
@@ -177,18 +178,11 @@ class RedshiftConnectMethodFactory:
                 "Invalid region provided: {}".format(kwargs["region"])
             )
 
-        if self.credentials.sslmode:
-            ssl_args, warning_msg = _translate_sslmode(self.credentials.sslmode)
-            logger.warning((self.credentials.sslmode).lower())
-            if warning_msg is not None:
-                logger.warning(warning_msg)
-            kwargs["ssl"] = ssl_args["ssl"]
-            kwargs["sslmode"] = ssl_args["sslmode"]
-        elif self.credentials.sslmode is None:
-            logger.warning(
-                "Establishing connection using ssl with sslmode set to 'verify-ca'. "
-                "To connect without ssl, set sslmode to 'disable'."
-            )
+        ssl_args, warning_msg = _translate_sslmode(self.credentials.sslmode)
+        if warning_msg is not None:
+            logger.warning(warning_msg)
+        kwargs["ssl"] = ssl_args["ssl"]
+        kwargs["sslmode"] = ssl_args["sslmode"]
 
         # Support missing 'method' for backwards compatibility
         if method == RedshiftConnectionMethod.DATABASE or method is None:

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -147,7 +147,33 @@ class RedshiftConnectMethodFactory:
             )
 
         if self.credentials.sslmode:
-            kwargs["sslmode"] = self.credentials.sslmode
+            if self.credentials.sslmode.lower() == "disable":
+                kwargs["ssl"] = False
+                logger.debug("Establishing connection without ssl.")
+            elif (
+                self.credentials.sslmode.lower() == "allow"
+                or self.credentials.sslmode.lower() == "prefer"
+            ):
+                kwargs["sslmode"] = "verify-ca"
+                logger.warning(
+                    "Establishing connection using ssl with sslmode set to 'verify-ca'. "
+                    "To connect without ssl, set sslmode to 'disable'."
+                )
+            elif (
+                self.credentials.sslmode.lower() == "verify-ca"
+                or self.credentials.sslmode.lower() == "verify-full"
+                or self.credentials.sslmode.lower() == "require"
+            ):
+                kwargs["sslmode"] = self.credentials.sslmode
+            else:
+                kwargs["sslmode"] = "verify-ca"
+                logger.warning(
+                    "Invalid sslmode provided. Supported values are 'disable', "
+                    "'allow', 'prefer', 'require', 'verify-ca', 'verify-full'. Using 'verify-ca' to connect."
+                )
+
+        # if self.credentials.ssl:
+        #     kwargs["ssl"] = self.credentials.ssl
 
         # Support missing 'method' for backwards compatibility
         if method == RedshiftConnectionMethod.DATABASE or method is None:

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -105,8 +105,8 @@ SSL_MODE_TRANSLATION = {
 
 @dataclass
 class RedshiftSSLConfig(dbtClassMixin):
-    ssl: bool
-    sslmode: Optional[RedshiftSSLMode]
+    ssl: bool = True
+    sslmode: Optional[RedshiftSSLMode] = SSL_MODE_TRANSLATION[UserSSLMode.default_field()]
 
     @classmethod
     def parse(cls, user_sslmode: UserSSLMode) -> "RedshiftSSLConfig":

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -59,11 +59,6 @@ class RedshiftConnectionMethod(StrEnum):
     IAM = "iam"
 
 
-class RedshiftSSLMode(StrEnum):
-    verify_ca = "verify-ca"
-    verify_full = "verify-full"
-
-
 class UserSSLMode(str, Metadata):
     disable = "disable"
     allow = "allow"
@@ -80,6 +75,11 @@ class UserSSLMode(str, Metadata):
     @classmethod
     def metadata_key(cls) -> str:
         return "sslmode"
+
+
+class RedshiftSSLMode(StrEnum):
+    verify_ca = "verify-ca"
+    verify_full = "verify-full"
 
 
 @dataclass(frozen=True)

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -111,6 +111,36 @@ def _is_valid_region(region):
     return region in _AVAILABLE_AWS_REGIONS
 
 
+def _translate_sslmode(sslmode_input):
+    sslmode_input = sslmode_input.lower()
+    args = {"ssl": True}
+    warning_msg = None
+    if sslmode_input == "disable":
+        args["ssl"] = False
+        args["sslmode"] = None
+        warning_msg = "Establishing connection without ssl."
+    elif sslmode_input == "allow" or sslmode_input == "prefer":
+        args["sslmode"] = "verify-ca"
+        warning_msg = (
+            "Establishing connection using ssl with sslmode set to 'verify-ca'. "
+            "To connect without ssl, set sslmode to 'disable'."
+        )
+
+    elif (
+        sslmode_input == "verify-ca"
+        or sslmode_input == "verify-full"
+        or sslmode_input == "require"
+    ):
+        args["sslmode"] = sslmode_input
+    else:
+        args["sslmode"] = "verify-ca"
+        warning_msg = (
+            "Invalid sslmode provided. Establishing connection using ssl with sslmode set to 'verify-ca'."
+            " Supported values are 'disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'."
+        )
+    return args, warning_msg
+
+
 class RedshiftConnectMethodFactory:
     credentials: RedshiftCredentials
 
@@ -147,33 +177,11 @@ class RedshiftConnectMethodFactory:
             )
 
         if self.credentials.sslmode:
-            if self.credentials.sslmode.lower() == "disable":
-                kwargs["ssl"] = False
-                logger.debug("Establishing connection without ssl.")
-            elif (
-                self.credentials.sslmode.lower() == "allow"
-                or self.credentials.sslmode.lower() == "prefer"
-            ):
-                kwargs["sslmode"] = "verify-ca"
-                logger.warning(
-                    "Establishing connection using ssl with sslmode set to 'verify-ca'. "
-                    "To connect without ssl, set sslmode to 'disable'."
-                )
-            elif (
-                self.credentials.sslmode.lower() == "verify-ca"
-                or self.credentials.sslmode.lower() == "verify-full"
-                or self.credentials.sslmode.lower() == "require"
-            ):
-                kwargs["sslmode"] = self.credentials.sslmode
-            else:
-                kwargs["sslmode"] = "verify-ca"
-                logger.warning(
-                    "Invalid sslmode provided. Supported values are 'disable', "
-                    "'allow', 'prefer', 'require', 'verify-ca', 'verify-full'. Using 'verify-ca' to connect."
-                )
-
-        # if self.credentials.ssl:
-        #     kwargs["ssl"] = self.credentials.ssl
+            ssl_args, warning_msg = _translate_sslmode(self.credentials.sslmode)
+            if warning_msg is not None:
+                logger.warning(warning_msg)
+            kwargs["ssl"] = ssl_args["ssl"]
+            kwargs["sslmode"] = ssl_args["sslmode"]
 
         # Support missing 'method' for backwards compatibility
         if method == RedshiftConnectionMethod.DATABASE or method is None:

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -113,7 +113,7 @@ def _is_valid_region(region):
 
 def _translate_sslmode(sslmode_input):
     args = {"ssl": True, "sslmode": "verify-ca"}
-    warning_msg = (
+    log_msg = (
         "Establishing connection using ssl with sslmode set to 'verify-ca'."
         "To connect without ssl, set sslmode to 'disable'."
     )
@@ -122,25 +122,25 @@ def _translate_sslmode(sslmode_input):
         if sslmode_input == "disable":
             args["ssl"] = False
             args["sslmode"] = None
-            warning_msg = "Establishing connection without ssl."
+            log_msg = "Establishing connection without ssl."
         elif (
             sslmode_input == "verify-ca"
             or sslmode_input == "verify-full"
             or sslmode_input == "require"
         ):
             args["sslmode"] = sslmode_input
-            warning_msg = None
+            log_msg = None
         elif sslmode_input == "none":
             args["sslmode"] = "verify-ca"
         elif sslmode_input != "allow" and sslmode_input != "prefer":
             args["sslmode"] = "verify-ca"
-            warning_msg = (
+            log_msg = (
                 "Redshift adapter: Invalid sslmode provided. Establishing connection using ssl with "
                 "sslmode set to 'verify-ca'. Supported values are 'disable', 'allow', 'prefer', 'require', "
                 "'verify-ca', 'verify-full'."
             )
 
-    return args, warning_msg
+    return args, log_msg
 
 
 class RedshiftConnectMethodFactory:
@@ -178,9 +178,9 @@ class RedshiftConnectMethodFactory:
                 "Invalid region provided: {}".format(kwargs["region"])
             )
 
-        ssl_args, warning_msg = _translate_sslmode(self.credentials.sslmode)
-        if warning_msg is not None:
-            logger.warning(warning_msg)
+        ssl_args, log_msg = _translate_sslmode(self.credentials.sslmode)
+        if log_msg is not None:
+            logger.debug(log_msg)
         kwargs["ssl"] = ssl_args["ssl"]
         kwargs["sslmode"] = ssl_args["sslmode"]
 

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -74,6 +74,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             timeout=None,
             region="us-east-1",
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -92,6 +94,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             region="us-east-1",
             timeout=None,
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -134,6 +138,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             region="us-east-1",
             timeout=30,
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -162,6 +168,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -188,6 +196,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -216,6 +226,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
+            ssl=True,
+            sslmode="verify-ca",
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -245,6 +257,8 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 timeout=None,
                 port=5439,
+                ssl=True,
+                sslmode="verify-ca",
             )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -274,6 +288,8 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 timeout=None,
                 port=5439,
+                ssl=True,
+                sslmode="verify-ca",
             )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -396,6 +412,8 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 port=5439,
                 timeout=None,
+                ssl=True,
+                sslmode="verify-ca",
             )
         self.assertTrue("'host' must be provided" in context.exception.msg)
 

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -12,13 +12,16 @@ from dbt.adapters.redshift import (
 )
 from dbt.clients import agate_helper
 from dbt.exceptions import FailedToConnectError
-from dbt.adapters.redshift.connections import RedshiftConnectMethodFactory
+from dbt.adapters.redshift.connections import RedshiftConnectMethodFactory, RedshiftSSLConfig
 from .utils import (
     config_from_parts_or_dicts,
     mock_connection,
     TestAdapterConversions,
     inject_adapter,
 )
+
+
+DEFAULT_SSL_CONFIG = RedshiftSSLConfig().to_dict()
 
 
 class TestRedshiftAdapter(unittest.TestCase):
@@ -74,8 +77,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             timeout=None,
             region="us-east-1",
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -94,8 +96,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             region="us-east-1",
             timeout=None,
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -116,11 +117,12 @@ class TestRedshiftAdapter(unittest.TestCase):
             user="",
             cluster_identifier="my_redshift",
             region="us-east-1",
+            timeout=None,
             auto_create=False,
             db_groups=[],
             profile=None,
-            timeout=None,
             port=5439,
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -138,8 +140,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             db_groups=[],
             region="us-east-1",
             timeout=30,
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -168,8 +169,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -196,8 +196,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -226,8 +225,7 @@ class TestRedshiftAdapter(unittest.TestCase):
             profile="test",
             timeout=None,
             port=5439,
-            ssl=True,
-            sslmode="verify-ca",
+            **DEFAULT_SSL_CONFIG,
         )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -257,8 +255,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 timeout=None,
                 port=5439,
-                ssl=True,
-                sslmode="verify-ca",
+                **DEFAULT_SSL_CONFIG,
             )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -288,8 +285,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 timeout=None,
                 port=5439,
-                ssl=True,
-                sslmode="verify-ca",
+                **DEFAULT_SSL_CONFIG,
             )
 
     @mock.patch("redshift_connector.connect", Mock())
@@ -305,8 +301,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
             region="us-east-1",
+            timeout=None,
             ssl=False,
             sslmode=None,
         )
@@ -324,8 +320,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
             region="us-east-1",
+            timeout=None,
             ssl=True,
             sslmode="verify-ca",
         )
@@ -343,8 +339,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
             region="us-east-1",
+            timeout=None,
             ssl=True,
             sslmode="verify-full",
         )
@@ -362,8 +358,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
             region="us-east-1",
+            timeout=None,
             ssl=True,
             sslmode="verify-ca",
         )
@@ -381,8 +377,8 @@ class TestRedshiftAdapter(unittest.TestCase):
             port=5439,
             auto_create=False,
             db_groups=[],
-            timeout=30,
             region="us-east-1",
+            timeout=None,
             ssl=True,
             sslmode="verify-ca",
         )
@@ -412,8 +408,7 @@ class TestRedshiftAdapter(unittest.TestCase):
                 profile="test",
                 port=5439,
                 timeout=None,
-                ssl=True,
-                sslmode="verify-ca",
+                **DEFAULT_SSL_CONFIG,
             )
         self.assertTrue("'host' must be provided" in context.exception.msg)
 

--- a/tests/unit/test_redshift_adapter.py
+++ b/tests/unit/test_redshift_adapter.py
@@ -277,6 +277,101 @@ class TestRedshiftAdapter(unittest.TestCase):
             )
 
     @mock.patch("redshift_connector.connect", Mock())
+    def test_sslmode_disable(self):
+        self.config.credentials.sslmode = "disable"
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            timeout=30,
+            region="us-east-1",
+            ssl=False,
+            sslmode=None,
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
+    def test_sslmode_allow(self):
+        self.config.credentials.sslmode = "allow"
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            timeout=30,
+            region="us-east-1",
+            ssl=True,
+            sslmode="verify-ca",
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
+    def test_sslmode_verify_full(self):
+        self.config.credentials.sslmode = "verify-full"
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            timeout=30,
+            region="us-east-1",
+            ssl=True,
+            sslmode="verify-full",
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
+    def test_sslmode_verify_ca(self):
+        self.config.credentials.sslmode = "verify-ca"
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            timeout=30,
+            region="us-east-1",
+            ssl=True,
+            sslmode="verify-ca",
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
+    def test_sslmode_prefer(self):
+        self.config.credentials.sslmode = "prefer"
+        connection = self.adapter.acquire_connection("dummy")
+        connection.handle
+        redshift_connector.connect.assert_called_once_with(
+            host="thishostshouldnotexist.test.us-east-1",
+            database="redshift",
+            user="root",
+            password="password",
+            port=5439,
+            auto_create=False,
+            db_groups=[],
+            timeout=30,
+            region="us-east-1",
+            ssl=True,
+            sslmode="verify-ca",
+        )
+
+    @mock.patch("redshift_connector.connect", Mock())
     @mock.patch("boto3.Session", Mock())
     def test_serverless_iam_failure(self):
         self.config.credentials = self.config.credentials.replace(


### PR DESCRIPTION
resolves #429

### Description

Translate from the user provided `sslmode` to the parameters required by the redshift connector in order to preserve the `dbt-redshift` config interface after the shift from `psycopg2` to `redshift-connector`.

Please see this PR for a significantly more detailed writeup: https://github.com/dbt-labs/dbt-redshift/pull/439. Thanks @jiezhen-chen for this work and the detail in the write-up. Most of the changes with my name attached revolve around reworking @jiezhen-chen's solution to align with pre-existing patterns in `dbt-core`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
