### PR TITLE
drop support for py37

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230530-165542.yaml
+++ b/.changes/unreleased/Breaking Changes-20230530-165542.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Drop support for python 3.7
+time: 2023-05-30T16:55:42.393416-04:00
+custom:
+  Author: mikealfare
+  Issue: dbt-core/7082

--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -1,6 +1,6 @@
 module.exports = ({ context }) => {
   const defaultPythonVersion = "3.8";
-  const supportedPythonVersions = ["3.7", "3.8", "3.9", "3.10", "3.11"];
+  const supportedPythonVersions = ["3.8", "3.9", "3.10", "3.11"];
   const supportedAdapters = ["redshift"];
 
   // if PR, generate matrix based on files changed and PR labels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     env:
       TOXENV: "unit"
@@ -176,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,7 +26,7 @@ defaults:
     shell: bash
 
 env:
-  RELEASE_BRANCH: "1.4.latest"
+  RELEASE_BRANCH: "main"
 
 jobs:
   aggregate-release-data:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ $EDITOR test.env
 There are a few methods for running tests locally.
 
 #### `tox`
-`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel. For example, you can run unit tests for Python 3.7, Python 3.8, Python 3.9, Python 3.10, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py37`. The configuration of these tests are located in `tox.ini`.
+`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel. For example, you can run unit tests for Python 3.8, Python 3.9, Python 3.10, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py38`. The configuration of these tests are located in `tox.ini`.
 
 #### `pytest`
 Finally, you can also run a specific test or group of tests using `pytest` directly. With a Python virtualenv active and dev dependencies installed you can do things like:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,15 +9,13 @@ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugi
 black~=23.3
 bumpversion~=0.6.0
 click~=8.1
-flake8~=5.0;python_version=="3.7"
-flake8~=6.0;python_version>="3.8"
+flake8~=6.0
 flaky~=3.7
 freezegun~=1.2
 ipdb~=0.13.13
 mypy==1.2.0  # patch updates have historically introduced breaking changes
 pip-tools~=6.13
-pre-commit~=2.21;python_version=="3.7"
-pre-commit~=3.2;python_version>="3.8"
+pre-commit~=3.2
 pre-commit-hooks~=4.4
 pytest~=7.3
 pytest-csv~=3.0
@@ -25,8 +23,7 @@ pytest-dotenv~=0.5.2
 pytest-logbook~=1.2
 pytest-xdist~=3.2
 pytz~=2023.3
-tox~=3.0;python_version=="3.7"
-tox~=4.5;python_version>="3.8"
+tox~=4.5
 types-pytz~=2023.3
 types-requests~=2.28
 twine~=4.0

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import sys
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.7 or higher.")
+    print("Please upgrade to Python 3.8 or higher.")
     sys.exit(1)
 
 
@@ -94,11 +94,10 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 
-[testenv:{unit,py37,py38,py39,py310,py311,py}]
+[testenv:{unit,py38,py39,py310,py311,py}]
 description = unit testing
 skip_install = true
 passenv =
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py37,py38,py39,py310,py311,py}-{redshift}]
+[testenv:{integration,py38,py39,py310,py311,py}-{redshift}]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
resolves dbt-labs/dbt-core#7082

### Description

Drop support for py37.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
