### PR TITLE
Revert "Escape `%` symbols in table/view/column comments (#466)"

### DIFF
--- a/dbt/include/redshift/macros/adapters.sql
+++ b/dbt/include/redshift/macros/adapters.sql
@@ -309,21 +309,3 @@
   {% endif %}
 
 {% endmacro %}
-
-{#
-  By using dollar-quoting like this, users can embed anything they want into their comments
-  (including nested dollar-quoting), as long as they do not use this exact dollar-quoting
-  label. It would be nice to just pick a new one but eventually you do have to give up.
-#}
-{% macro postgres_escape_comment(comment) -%}
-  {% if comment is not string %}
-    {% do exceptions.raise_compiler_error('cannot escape a non-string: ' ~ comment) %}
-  {% endif %}
-  {%- set magic = '$dbt_comment_literal_block$' -%}
-  {%- if magic in comment -%}
-    {%- do exceptions.raise_compiler_error('The string ' ~ magic ~ ' is not allowed in comments.') -%}
-  {%- endif -%}
-  {#- -- escape % until the underlying issue is fixed in redshift_connector -#}
-  {%- set comment = comment|replace("%", "%%") -%}
-  {{ magic }}{{ comment }}{{ magic }}
-{%- endmacro %}


### PR DESCRIPTION
This reverts commit adb44828fefff91dd6e97ee20ee8fb7e395a2ece.

### Description

After the release of `redshift_connector` [2.0.911](https://pypi.org/project/redshift-connector/2.0.911/), we don't need (or want) https://github.com/dbt-labs/dbt-redshift/pull/466 anymore. If it is left in, then extra % characters will be introduced within comments.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] Docs changes are not required/relevant for this PR
- Nope - ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~
    - [x] Added `Skip Changelog` label
