### PR TITLE
exclude redshift-connector==2.0.912

### DIFF
--- a/.changes/unreleased/Fixes-20230706-001056.yaml
+++ b/.changes/unreleased/Fixes-20230706-001056.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression in redshift-connector==2.0.912
+time: 2023-07-06T00:10:56.337407-04:00
+custom:
+  Author: mikealfare
+  Issue: "518"

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         f"dbt-core~={_core_version()}",
         f"dbt-postgres~={_core_version()}",
         "boto3~=1.26.26",
-        "redshift-connector~=2.0.911",
+        "redshift-connector~=2.0.911,!=2.0.912",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],


### PR DESCRIPTION
resolves #518

### Description

Exclude `dbt-redshift==2.0.912` due to a regression in the patch release.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
