### PR TITLE
Add new `defer_relation` argument to `mock_model`

### DIFF
--- a/.changes/unreleased/Fixes-20230706-001056.yaml
+++ b/.changes/unreleased/Fixes-20230706-001056.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix regression in redshift-connector==2.0.912
+time: 2023-07-06T00:10:56.337407-04:00
+custom:
+  Author: mikealfare
+  Issue: "518"

--- a/.changes/unreleased/Fixes-20230706-012233.yaml
+++ b/.changes/unreleased/Fixes-20230706-012233.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixed unit test that broke following dbt clone work
+time: 2023-07-06T01:22:33.840137-04:00
+custom:
+  Author: mikealfare
+  Issue: "518"

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         f"dbt-core~={_core_version()}",
         f"dbt-postgres~={_core_version()}",
         "boto3~=1.26.26",
-        "redshift-connector~=2.0.911",
+        "redshift-connector~=2.0.911,!=2.0.912",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -147,6 +147,7 @@ def mock_model():
         raw_sql="",
         description="",
         columns={},
+        defer_relation=None,
     )
 
 


### PR DESCRIPTION
### Description

`defer_relation` is an optional argument that was added to `ModelNode` as part of the `dbt clone` work. Despite it being optional, `MagicMock` was trying to mock it up, which failed validation tests on `Path`. This new argument was added to the mock parameters with a value of `None` to avoid creating it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-redshift/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
