### PR TITLE
add query commenting back

### DIFF
--- a/.changes/unreleased/Fixes-20230713-190412.yaml
+++ b/.changes/unreleased/Fixes-20230713-190412.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: re-enable query commenting
+time: 2023-07-13T19:04:12.580073-04:00
+custom:
+  Author: dataders
+  Issue: "536"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -353,6 +353,7 @@ class RedshiftConnectionManager(SQLConnectionManager):
         fetch: bool = False,
         limit: Optional[int] = None,
     ) -> Tuple[AdapterResponse, agate.Table]:
+        sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:


### PR DESCRIPTION
resolves #536 

No [docs updates](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) needed.

### Problem

[this gist](https://gist.github.com/dataders/5dfdc66a80031733ea8582c2a1976cfa/revisions/?diff=split) shows that `sql = self._add_query_comment(sql)` was removed as part of #251. and never added back. this omission was not picked up due to faulty tests that were surfaced in https://github.com/dbt-labs/dbt-core/issues/7845 and fixed in https://github.com/dbt-labs/dbt-core/pull/7928.

### Solution

Add it back 😎

Vive les commentaires de requête !

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc)
