### PR TITLE
Point `setup.py` to `dbt-core/main` to pick up the alpha

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,6 @@
 # install latest changes in dbt-core + dbt-postgres
 # TODO: how to switch from HEAD to x.y.latest branches after minor releases?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,12 @@ from pathlib import Path
 from setuptools import setup
 
 
-# pull the long description from the README
+# pull the long description from the README and the version from `__version__.py`
 README = Path(__file__).parent / "README.md"
-
-
-# used for this adapter's version and in determining the compatible dbt-core version
 VERSION = Path(__file__).parent / "dbt/adapters/redshift/__version__.py"
 
 
-def _plugin_version() -> str:
+def version() -> str:
     """
     Pull the package version from the main package version file
     """
@@ -36,43 +33,9 @@ def _plugin_version() -> str:
     return attributes["version"]
 
 
-def _core_patch(plugin_patch: str):
-    """
-    Determines the compatible dbt-core patch given this plugin's patch
-
-    Args:
-        plugin_patch: the version patch of this plugin
-    """
-    pre_release_phase = "".join([i for i in plugin_patch if not i.isdigit()])
-    if pre_release_phase:
-        if pre_release_phase not in ["a", "b", "rc"]:
-            raise ValueError(f"Invalid prerelease patch: {plugin_patch}")
-        return f"0{pre_release_phase}1"
-    return "0"
-
-
-# require a compatible minor version (~=) and prerelease if this is a prerelease
-def _core_version(plugin_version: str = _plugin_version()) -> str:
-    """
-    Determine the compatible dbt-core version give this plugin's version.
-
-    We assume that the plugin must agree with `dbt-core` down to the minor version.
-
-    Args:
-        plugin_version: the version of this plugin, this is an argument in case we ever want to unit test this
-    """
-    try:
-        # *_ may indicate a dev release which won't affect the core version needed
-        major, minor, plugin_patch, *_ = plugin_version.split(".", maxsplit=3)
-    except ValueError:
-        raise ValueError(f"Invalid version: {plugin_version}")
-
-    return f"{major}.{minor}.{_core_patch(plugin_patch)}"
-
-
 setup(
     name="dbt-redshift",
-    version=_plugin_version(),
+    version=version(),
     description="The Redshift adapter plugin for dbt",
     long_description=README.read_text(),
     long_description_content_type="text/markdown",
@@ -82,10 +45,11 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        f"dbt-core~={_core_version()}",
-        f"dbt-postgres~={_core_version()}",
+        "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core",
+        "dbt-postgres @ git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres",
         "boto3~=1.26.157",
-        # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
+        # dbt-redshift depends deeply on this package. it does not follow SemVer,
+        # therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector==2.0.913",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core


### PR DESCRIPTION
### Problem

This repo currently has `dbt-core~=1.7.0a1` as a dependency; however, this version of `dbt-core` has not, and will not, be published to PyPI. Hence the dependency is not available when limited to PyPI.

### Solution

Point `setup.py` directly to `dbt-core@main` in the same way `dev-requirements.txt` points to `main`. Remove the now unnecessary entries in `dev-requirements.txt` as well as the version related functions in `setup.py`.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
