### PR TITLE
ADAP-796: Add datadog env vars to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,11 @@ passenv =
     DBT_*
     REDSHIFT_TEST_*
     PYTEST_ADDOPTS
-    DD_SERVICE
+    DD_CIVISIBILITY_AGENTLESS_ENABLED
+    DD_API_KEY
+    DD_SITE
     DD_ENV
+    DD_SERVICE
 commands =
   {envpython} -m pytest --dist=loadscope {posargs} tests/functional -k "not tests/functional/adapter/utils"
   {envpython} -m pytest --dist=loadscope {posargs} tests/functional/adapter/utils


### PR DESCRIPTION
### Problem

We were missing env vars in tox for data dog.

### Solution

Add them to tox.ini

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
