### PR TITLE
Remove import of FieldEncoder from hologram

### DIFF
--- a/.changes/unreleased/Fixes-20230830-164611.yaml
+++ b/.changes/unreleased/Fixes-20230830-164611.yaml
@@ -1,5 +1,5 @@
 kind: Fixes
-body: Fix to support removal of hologram
+body: Fix to support removal of hologram, remove unused IAMDuration encoder
 time: 2023-08-30T16:46:11.83975-04:00
 custom:
   Author: gshank

--- a/.changes/unreleased/Fixes-20230830-164611.yaml
+++ b/.changes/unreleased/Fixes-20230830-164611.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix to support removal of hologram
+time: 2023-08-30T16:46:11.83975-04:00
+custom:
+  Author: gshank
+  Issue: "591"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -1,7 +1,7 @@
 import re
 from multiprocessing import Lock
 from contextlib import contextmanager
-from typing import NewType, Tuple, Union, Optional, List
+from typing import Tuple, Union, Optional, List
 from dataclasses import dataclass, field
 
 import agate
@@ -12,7 +12,7 @@ from redshift_connector.utils.oids import get_datatype_name
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import AdapterResponse, Connection, Credentials
 from dbt.contracts.util import Replaceable
-from dbt.dataclass_schema import FieldEncoder, dbtClassMixin, StrEnum, ValidationError
+from dbt.dataclass_schema import dbtClassMixin, StrEnum, ValidationError
 from dbt.events import AdapterLogger
 from dbt.exceptions import DbtRuntimeError, CompilationError
 import dbt.flags
@@ -34,18 +34,6 @@ logger = AdapterLogger("Redshift")
 
 
 drop_lock: Lock = dbt.flags.MP_CONTEXT.Lock()  # type: ignore
-
-
-IAMDuration = NewType("IAMDuration", int)
-
-
-class IAMDurationEncoder(FieldEncoder):
-    @property
-    def json_schema(self):
-        return {"type": "integer", "minimum": 0, "maximum": 65535}
-
-
-dbtClassMixin.register_field_encoders({IAMDuration: IAMDurationEncoder()})
 
 
 class RedshiftConnectionMethod(StrEnum):


### PR DESCRIPTION
resolves #592

### Problem

dbt-core removed hologram as a dependency. FieldEncoder was being imported from hologram.


### Solution

Remove FieldEncoder and its registered encoder, since it doesn't appear to be used.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
