### PR TITLE
[ADAP-878] update expected values

### DIFF
--- a/.changes/unreleased/Fixes-20230908-113019.yaml
+++ b/.changes/unreleased/Fixes-20230908-113019.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: changes expected value types to AnyInteger to take into account changes in core
+time: 2023-09-08T11:30:19.77143-05:00
+custom:
+  Author: McKnight-42
+  Issue: "597"

--- a/tests/functional/adapter/expected_stats.py
+++ b/tests/functional/adapter/expected_stats.py
@@ -1,4 +1,4 @@
-from dbt.tests.util import AnyStringWith, AnyFloat, AnyString
+from dbt.tests.util import AnyStringWith, AnyInteger, AnyString, AnyFloat
 
 
 def redshift_stats():
@@ -27,14 +27,14 @@ def redshift_stats():
         "max_varchar": {
             "id": "max_varchar",
             "label": "Max Varchar",
-            "value": AnyFloat(),
+            "value": AnyInteger(),
             "description": "Size of the largest column that uses a VARCHAR data type.",
             "include": True,
         },
         "size": {
             "id": "size",
             "label": "Approximate Size",
-            "value": AnyFloat(),
+            "value": AnyInteger(),
             "description": "Approximate size of the table, calculated from a count of 1MB blocks",
             "include": True,
         },


### PR DESCRIPTION
resolves #597 
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
change to agate_helper in core requires an update to the data type expected value in the test.

This pr is dbt-redshift versions of earlier work we did but had to revert in dbt-bigquery see: https://github.com/dbt-labs/dbt-bigquery/pull/890 and https://github.com/dbt-labs/dbt-bigquery/pull/894
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
merge into main and backport to 1.6.latest when core does
<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
