### PR TITLE
allow for bool/str input to backup/autorefresh when configuring materialized views

### DIFF
--- a/.changes/unreleased/Under the Hood-20230914-135547.yaml
+++ b/.changes/unreleased/Under the Hood-20230914-135547.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: allow for bool/str input to backup/autorefresh when configuring materialized
+  views
+time: 2023-09-14T13:55:47.951848-07:00
+custom:
+  Author: colin-rogers-dbt

--- a/dbt/adapters/redshift/utility.py
+++ b/dbt/adapters/redshift/utility.py
@@ -1,0 +1,25 @@
+from typing import Union
+
+
+def evaluate_bool_str(value: str) -> bool:
+    value = value.strip().lower()
+    if value == "true":
+        return True
+    elif value == "false":
+        return False
+    else:
+        raise ValueError(f"Invalid boolean string value: {value}")
+
+
+def evaluate_bool(value: Union[str, bool]) -> bool:
+    if not value:
+        return False
+    if isinstance(value, bool):
+        return value
+    elif isinstance(value, str):
+        return evaluate_bool_str(value)
+    else:
+        raise TypeError(
+            f"Invalid type for boolean evaluation, "
+            f"expecting boolean or str, recieved: {type(value)}"
+        )

--- a/tests/functional/adapter/materialized_view_tests/test_materialized_views.py
+++ b/tests/functional/adapter/materialized_view_tests/test_materialized_views.py
@@ -261,4 +261,5 @@ class TestRedshiftMaterializedViewWithBackupConfig:
 
     def test_running_mv_with_backup_false_succeeds(self, project):
         run_dbt(["seed"])
-        run_dbt(["run"])
+        result = run_dbt(["run"])
+        assert result[0].node.config_call_dict["backup"] is False

--- a/tests/unit/relation_configs/test_materialized_view.py
+++ b/tests/unit/relation_configs/test_materialized_view.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+import pytest
+
+from dbt.adapters.redshift.relation_configs import RedshiftMaterializedViewConfig
+
+
+@pytest.mark.parametrize("bool_value", [True, False, "True", "False", "true", "false"])
+def test_redshift_materialized_view_config_handles_all_valid_bools(bool_value):
+    config = RedshiftMaterializedViewConfig(
+        database_name="somedb",
+        schema_name="public",
+        mv_name="someview",
+        query="select * from sometable",
+    )
+    model_node = Mock()
+    model_node.config.extra.get = (
+        lambda x, y=None: bool_value if x in ["auto_refresh", "backup"] else "someDistValue"
+    )
+    config_dict = config.parse_model_node(model_node)
+    assert isinstance(config_dict["autorefresh"], bool)
+    assert isinstance(config_dict["backup"], bool)
+
+
+@pytest.mark.parametrize("bool_value", [1])
+def test_redshift_materialized_view_config_throws_expected_exception_with_invalid_types(
+    bool_value,
+):
+    config = RedshiftMaterializedViewConfig(
+        database_name="somedb",
+        schema_name="public",
+        mv_name="someview",
+        query="select * from sometable",
+    )
+    model_node = Mock()
+    model_node.config.extra.get = (
+        lambda x, y=None: bool_value if x in ["auto_refresh", "backup"] else "someDistValue"
+    )
+    with pytest.raises(TypeError):
+        config.parse_model_node(model_node)
+
+
+def test_redshift_materialized_view_config_throws_expected_exception_with_invalid_str():
+    config = RedshiftMaterializedViewConfig(
+        database_name="somedb",
+        schema_name="public",
+        mv_name="someview",
+        query="select * from sometable",
+    )
+    model_node = Mock()
+    model_node.config.extra.get = (
+        lambda x, y=None: "notABool" if x in ["auto_refresh", "backup"] else "someDistValue"
+    )
+    with pytest.raises(ValueError):
+        config.parse_model_node(model_node)


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
