### PR TITLE
Avoid nested loop in query planner execution

### DIFF
--- a/.changes/unreleased/Fixes-20230923-091155.yaml
+++ b/.changes/unreleased/Fixes-20230923-091155.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: avoid nested loop in query planner execution of redshift__get_relations
+time: 2023-09-23T09:11:55.2152725-04:00
+custom:
+  Author: slin30
+  Issue: "609"

--- a/dbt/include/redshift/macros/relations.sql
+++ b/dbt/include/redshift/macros/relations.sql
@@ -24,6 +24,7 @@ with
         from pg_depend
         left join pg_rewrite
           on pg_depend.objid = pg_rewrite.oid
+        where coalesce(pg_rewrite.ev_class, pg_depend.objid) != pg_depend.refobjid
     )
 
 select distinct
@@ -36,7 +37,6 @@ join relation ref
     on dependency.ref_relation_id = ref.relation_id
 join relation dep
     on dependency.dep_relation_id = dep.relation_id
-where ref.relation_name != dep.relation_name
 
 {%- endcall -%}
 


### PR DESCRIPTION
  
- Move relation name `not equals` from outer SELECT `where` clause to dependency CTE 
  - Seems to more reliably push query planner to avoid a nested loop 
  - Should preserve original intent, i.e. to exclude self-references from final result 
  - Execution plan suggests this reduces the row estimate for the outer SELECT 
  - Real-world testing on internal company cluster under conditions where nested loop is used for original, shows that the new approach continues to perform and behave as expected (no nested loop)

resolves #609

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
> copied from issue *Current Behavior*

When running the statement in [relations.sql](https://github.com/dbt-labs/dbt-redshift/blob/538ad793769269454ff390135566a85d729fcdcc/dbt/include/redshift/macros/relations.sql), our Redshift cluster query planner will, seemingly at random, expect to use a nested loop join. This reflects in extended execution times, adding anywhere from 1-6 minutes to the start of a run/step.

### Solution
> copied from issue *Additional Context*

The original logic that threw the planner for a loop (no pun intended) was the `WHERE !=` in the outer statement. Removing this or setting it to `=`, or pushing it into the `select` as an `=` flag, works fine. For the latter, if I subsequently attempt to filter on the flag (with `NOT`), this predictably ends up with the same nested loop execution plan -- it's the attempt to filter on *not equals* in the outer `select` that triggers the nested loop (when the anomaly manifests).

My adjustment simply pushes the evaluation up to the `dependency` CTE. My thinking was that in doing so, the planner should choose a more efficient path under more conditions. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
    - NOT run on my end -- simply updated the sole `relations.sql` file
    - Update: while this is not a general test, the updated version has been running in our internal dbt implementation (via local macro override) as of Sept 22, 2023. This (a) resolved the recurrence of the nested loop plan and (b) has been running without issue since. Please see [comment ](https://github.com/dbt-labs/dbt-redshift/issues/609#issuecomment-1731706968)in issue.
- [x] This PR includes tests, or **tests are not** required/**relevant** for this PR
    - Not aware if unit tests are supplied for this specific macro, but if they are, I've not run them.
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
    - This PR is for one specific macro, and it definitely needs to be reviewed and tested before merging.

### Supplemental

Please see local benchmark comparing the original versus new, `10` runs of each with `cache=off`, a new session for each run, and a one-second pause between each run. This comparison is under **normal** conditions, i.e. the query planner does not expect to use a nested loop for the original. It should be a fair comparison (for our environment) of the performance delta, if any, for the two versions (my conclusion is that there is no performance difference). 

Also, a row count of the results for each run, across the two groups. This is a light QC check on result equality across runs and between groups. Note y-axes are zoomed in to highlight any diffs and are relative to each metric.

![image](https://github.com/dbt-labs/dbt-redshift/assets/13291275/48925874-52bc-4012-b064-e616ddaf9a79)
