### PR TITLE
adding IAM role authentication support for redshift

### DIFF
--- a/dbt/include/redshift/profile_template.yml
+++ b/dbt/include/redshift/profile_template.yml
@@ -15,6 +15,8 @@ prompts:
         hide_input: true
     iam:
       _fixed_method: iam
+    iamr:
+      _fixed_method: iamr
   dbname:
     hint: 'default database that dbt will build objects in'
   schema:


### PR DESCRIPTION
resolves #623
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

### Problem

dbt-redshift currently does not natively support the redshift authentication method [get-cluster-credentials-with-iam](https://docs.aws.amazon.com/cli/latest/reference/redshift/get-cluster-credentials-with-iam.html). A dbt customer using IAM roles as db users currently has no way to authenticate as those users.

### Solution
There is now a new redshift connection method to authenticate as an IAM role, called IAMR. This strongly resembles the classic IAM authentication, except the user field is unnecessary.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
