### PR TITLE
Fixes #641 by using the svv_mv_info view which is queryable

### DIFF
--- a/.changes/unreleased/Fixes-20231026-164623.yaml
+++ b/.changes/unreleased/Fixes-20231026-164623.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix describe_materialized_view for Redshift Serverless
+time: 2023-10-26T16:46:23.253837-06:00
+custom:
+  Author: reptillicus
+  Issue: "641"

--- a/dbt/include/redshift/macros/relations/materialized_view/describe.sql
+++ b/dbt/include/redshift/macros/relations/materialized_view/describe.sql
@@ -13,6 +13,7 @@
             tb.sortkey1,
             mv.autorefresh
         from svv_table_info tb
+        -- svv_mv_info is queryable by Redshift Serverless, but stv_mv_info is not
         left join svv_mv_info mv
             on mv.database_name = tb.database
             and mv.schema_name = tb.schema

--- a/dbt/include/redshift/macros/relations/materialized_view/describe.sql
+++ b/dbt/include/redshift/macros/relations/materialized_view/describe.sql
@@ -13,9 +13,9 @@
             tb.sortkey1,
             mv.autorefresh
         from svv_table_info tb
-        left join stv_mv_info mv
-            on mv.db_name = tb.database
-            and mv.schema = tb.schema
+        left join svv_mv_info mv
+            on mv.database_name = tb.database
+            and mv.schema_name = tb.schema
             and mv.name = tb.table
         where tb.table ilike '{{ relation.identifier }}'
         and tb.schema ilike '{{ relation.schema }}'


### PR DESCRIPTION

resolves #641
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
When doing a dbt run on a redshift serverless cluster, permission denied errors will happen when dbt attempts to query the svt_mv_info table. This is due to that table not being queryable by any user in redshift serverless [as described here](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-monitoring.html#serverless_views-monitoring).
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution
This can be remedied by a custom macro for redshift__describe_materialized_view, which references the svv_mv_info view instead of the svt_mv_info table as shown below


<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
