### PR TITLE
allow user to set debug level via env var

### DIFF
--- a/.changes/unreleased/Features-20231030-101055.yaml
+++ b/.changes/unreleased/Features-20231030-101055.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: allow user to set debug level for redshift-connector via env var
+time: 2023-10-30T10:10:55.976191-07:00
+custom:
+  Author: colin-rogers-dbt
+  Issue: "650"

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Optional, Set, Any, Dict, Type
 from collections import namedtuple
@@ -14,9 +15,15 @@ import dbt.exceptions
 
 from dbt.adapters.redshift import RedshiftConnectionManager, RedshiftRelation
 
-
 logger = AdapterLogger("Redshift")
-
+packages = ["redshift_connector", "redshift_connector.core"]
+if os.getenv("DBT_REDSHIFT_CONNECTOR_DEBUG_LOGGING"):
+    level = "DEBUG"
+else:
+    level = "ERROR"
+for package in packages:
+    logger.debug(f"Setting {package} to {level}")
+    logger.set_adapter_dependency_log_level(package, level)
 
 GET_RELATIONS_MACRO_NAME = "redshift__get_relations"
 


### PR DESCRIPTION
This change follows a similar pattern to [dbt-snowflake](https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/connections.py#L53) to allow an adapter to configure it's dependencies' logging, this has the added benefit of not having the debug logs for redshift-connector turned on by default during testing. 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
