### PR TITLE
[Backport 1.7.latest] Fixes #641 by using the svv_mv_info view which is queryable

### DIFF
--- a/.changes/unreleased/Fixes-20231026-164623.yaml
+++ b/.changes/unreleased/Fixes-20231026-164623.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix describe_materialized_view for Redshift Serverless
+time: 2023-10-26T16:46:23.253837-06:00
+custom:
+  Author: reptillicus
+  Issue: "641"

--- a/dbt/include/redshift/macros/relations/materialized_view/describe.sql
+++ b/dbt/include/redshift/macros/relations/materialized_view/describe.sql
@@ -13,9 +13,10 @@
             tb.sortkey1,
             mv.autorefresh
         from svv_table_info tb
-        left join stv_mv_info mv
-            on mv.db_name = tb.database
-            and mv.schema = tb.schema
+        -- svv_mv_info is queryable by Redshift Serverless, but stv_mv_info is not
+        left join svv_mv_info mv
+            on mv.database_name = tb.database
+            and mv.schema_name = tb.schema
             and mv.name = tb.table
         where tb.table ilike '{{ relation.identifier }}'
         and tb.schema ilike '{{ relation.schema }}'


### PR DESCRIPTION
Backport 058a3ffa2aff4b556d495667912ce50028da9cd0 from #647.