### PR TITLE
upgrade 1.7.latest redshift driver constraint to allow for `<=2.0.918, >=2.0.913`

### DIFF
--- a/.changes/unreleased/Dependencies-20240118-095740.yaml
+++ b/.changes/unreleased/Dependencies-20240118-095740.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: upgrade redshift driver constraint to allow for `<=2.0.918, >=2.0.913`
+time: 2024-01-18T09:57:40.844744-08:00
+custom:
+  Author: colin-rogers-dbt
+  PR: "703"

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         f"dbt-postgres~={_core_version()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-        "redshift-connector==2.0.915",
+        "redshift-connector<=2.0.918, >=2.0.913",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         f"dbt-postgres~={_core_version()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-        "redshift-connector<=2.0.918, >=2.0.913",
+        "redshift-connector<=2.0.918, >=2.0.913, !=2.0.914",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "agate",
     ],


### PR DESCRIPTION


resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
