### PR TITLE
[Bug] Initialize sqlparse lexer prior to using sqlparse

### DIFF
--- a/.changes/unreleased/Fixes-20240206-132326.yaml
+++ b/.changes/unreleased/Fixes-20240206-132326.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Initialize sqlparse.Lexer to resolve issue with `dbt docs generate` that includes
+  external tables
+time: 2024-02-06T13:23:26.061133-05:00
+custom:
+  Author: mikealfare
+  Issue: "710"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -354,6 +354,7 @@ class RedshiftConnectionManager(SQLConnectionManager):
         connection = None
         cursor = None
 
+        self._initialize_sqlparse_lexer()
         queries = sqlparse.split(sql)
 
         for query in queries:
@@ -385,3 +386,14 @@ class RedshiftConnectionManager(SQLConnectionManager):
     @classmethod
     def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:
         return get_datatype_name(type_code)
+
+    @staticmethod
+    def _initialize_sqlparse_lexer():
+        """
+        Resolves: https://github.com/dbt-labs/dbt-redshift/issues/710
+        Implementation of this fix: https://github.com/dbt-labs/dbt-core/pull/8215
+        """
+        from sqlparse.lexer import Lexer  # type: ignore
+
+        if hasattr(Lexer, "get_default_instance"):
+            Lexer.get_default_instance()


### PR DESCRIPTION
resolves #710

### Problem

We are seeing an error when running `dbt docs generate` on a set of sources that uses external tables. This error is similar to what we saw here: https://github.com/dbt-labs/dbt-core/issues/8217.

### Solution

We need to initialize `Lexer` in `sqlparse` prior to using `sqlparse`, as is done in this PR: https://github.com/dbt-labs/dbt-core/pull/8215

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
