### PR TITLE
[Bug] Python driver 2.0.918 causes SSL error. Need to revert back to 2.0.917

### DIFF
--- a/.changes/unreleased/Fixes-20240317-113447.yaml
+++ b/.changes/unreleased/Fixes-20240317-113447.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin `redshift-connector` to <2.0.918 to avoid SSL error introduced in 2.0.918
+time: 2024-03-17T11:34:47.873169-04:00
+custom:
+  Author: mikealfare
+  Issue: "730"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         f"dbt-postgres~={_plugin_version()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-        "redshift-connector<=2.0.918, >=2.0.913, !=2.0.914",
+        "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "sqlparse>=0.2.3,<0.5",
         "agate",


### PR DESCRIPTION
resolves #730

### Problem

A bug causing an SSL error was introduced to `redshift-connector` in `2.0.918`.

### Solution

We need to pin `redshift-connector` to `<2.0.917` to resolve the issue for now. We will need to determine a long term solution, which may be as simple as skipping `2.0.918`, as we did with `2.0.914`, after `redshift-connector` resolves the underlying issue.

This will need to be backported to `1.7.latest`, where it was introduced.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
