### PR TITLE
lazy load `agate`

### DIFF
--- a/.changes/unreleased/Under the Hood-20240331-103115.yaml
+++ b/.changes/unreleased/Under the Hood-20240331-103115.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Lazy load agate
+time: 2024-03-31T10:31:15.65006-04:00
+custom:
+  Author: dwreeves
+  Issue: "745"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -1,14 +1,12 @@
 import re
 from multiprocessing import Lock
 from contextlib import contextmanager
-from typing import Tuple, Union, Optional, List
+from typing import Tuple, Union, Optional, List, TYPE_CHECKING
 from dataclasses import dataclass, field
 
-import agate
 import sqlparse
 import redshift_connector
 from dbt.adapters.exceptions import FailedToConnectError
-from dbt_common.clients import agate_helper
 from redshift_connector.utils.oids import get_datatype_name
 
 from dbt.adapters.sql import SQLConnectionManager
@@ -18,6 +16,9 @@ from dbt_common.contracts.util import Replaceable
 from dbt_common.dataclass_schema import dbtClassMixin, StrEnum, ValidationError
 from dbt_common.helper_types import Port
 from dbt_common.exceptions import DbtRuntimeError, CompilationError, DbtDatabaseError
+
+if TYPE_CHECKING:
+    import agate
 
 
 class SSLConfigError(CompilationError):
@@ -340,13 +341,15 @@ class RedshiftConnectionManager(SQLConnectionManager):
         auto_begin: bool = False,
         fetch: bool = False,
         limit: Optional[int] = None,
-    ) -> Tuple[AdapterResponse, agate.Table]:
+    ) -> Tuple[AdapterResponse, "agate.Table"]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:
             table = self.get_result_from_cursor(cursor, limit)
         else:
+            from dbt_common.clients import agate_helper
+
             table = agate_helper.empty_table()
         return response, table
 

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -1,7 +1,7 @@
 import os
 from dataclasses import dataclass
 from dbt_common.contracts.constraints import ConstraintType
-from typing import Optional, Set, Any, Dict, Type
+from typing import Optional, Set, Any, Dict, Type, TYPE_CHECKING
 from collections import namedtuple
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
@@ -27,6 +27,9 @@ for package in packages:
     logger.set_adapter_dependency_log_level(package, level)
 
 GET_RELATIONS_MACRO_NAME = "redshift__get_relations"
+
+if TYPE_CHECKING:
+    import agate
 
 
 @dataclass
@@ -84,7 +87,7 @@ class RedshiftAdapter(SQLAdapter):
             return super().drop_relation(relation)
 
     @classmethod
-    def convert_text_type(cls, agate_table, col_idx):
+    def convert_text_type(cls, agate_table: "agate.Table", col_idx):
         column = agate_table.columns[col_idx]
         # `lens` must be a list, so this can't be a generator expression,
         # because max() raises ane exception if its argument has no members.
@@ -93,7 +96,7 @@ class RedshiftAdapter(SQLAdapter):
         return "varchar({})".format(max_len)
 
     @classmethod
-    def convert_time_type(cls, agate_table, col_idx):
+    def convert_time_type(cls, agate_table: "agate.Table", col_idx):
         return "varchar(24)"
 
     @available

--- a/dbt/adapters/redshift/relation_configs/base.py
+++ b/dbt/adapters/redshift/relation_configs/base.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Optional, Dict, TYPE_CHECKING
 
-import agate
 from dbt.adapters.base.relation import Policy
 from dbt.adapters.contracts.relation import ComponentName, RelationConfig
 from dbt.adapters.relation_configs import (
@@ -14,6 +13,9 @@ from dbt.adapters.redshift.relation_configs.policies import (
     RedshiftIncludePolicy,
     RedshiftQuotePolicy,
 )
+
+if TYPE_CHECKING:
+    import agate
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
@@ -63,8 +65,10 @@ class RedshiftRelationConfigBase(RelationConfigBase):
         return None
 
     @classmethod
-    def _get_first_row(cls, results: agate.Table) -> agate.Row:
+    def _get_first_row(cls, results: "agate.Table") -> "agate.Row":
         try:
             return results.rows[0]
         except IndexError:
+            import agate
+
             return agate.Row(values=set())

--- a/dbt/adapters/redshift/relation_configs/dist.py
+++ b/dbt/adapters/redshift/relation_configs/dist.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from dbt.adapters.contracts.relation import RelationConfig
-from typing import Optional, Set, Dict
+from typing import Optional, Set, Dict, TYPE_CHECKING
 
-import agate
 from dbt.adapters.relation_configs import (
     RelationConfigChange,
     RelationConfigChangeAction,
@@ -14,6 +13,9 @@ from dbt_common.exceptions import DbtRuntimeError
 from typing_extensions import Self
 
 from dbt.adapters.redshift.relation_configs.base import RedshiftRelationConfigBase
+
+if TYPE_CHECKING:
+    import agate
 
 
 class RedshiftDistStyle(StrEnum):
@@ -108,7 +110,7 @@ class RedshiftDistConfig(RedshiftRelationConfigBase, RelationConfigValidationMix
         return config
 
     @classmethod
-    def parse_relation_results(cls, relation_results_entry: agate.Row) -> Dict:
+    def parse_relation_results(cls, relation_results_entry: "agate.Row") -> Dict:
         """
         Translate agate objects from the database into a standard dictionary.
 

--- a/dbt/adapters/redshift/relation_configs/materialized_view.py
+++ b/dbt/adapters/redshift/relation_configs/materialized_view.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
-from typing import Optional, Set, Dict, Any
+from typing import Optional, Set, Dict, Any, TYPE_CHECKING
 
-import agate
 from dbt.adapters.relation_configs import (
     RelationResults,
     RelationConfigChange,
@@ -24,6 +23,9 @@ from dbt.adapters.redshift.relation_configs.sort import (
     RedshiftSortConfigChange,
 )
 from dbt.adapters.redshift.utility import evaluate_bool
+
+if TYPE_CHECKING:
+    import agate
 
 
 @dataclass(frozen=True, eq=True, unsafe_hash=True)
@@ -173,10 +175,10 @@ class RedshiftMaterializedViewConfig(RedshiftRelationConfigBase, RelationConfigV
 
         Returns: a standard dictionary describing this `RedshiftMaterializedViewConfig` instance
         """
-        materialized_view: agate.Row = cls._get_first_row(
+        materialized_view: "agate.Row" = cls._get_first_row(
             relation_results.get("materialized_view")
         )
-        query: agate.Row = cls._get_first_row(relation_results.get("query"))
+        query: "agate.Row" = cls._get_first_row(relation_results.get("query"))
 
         config_dict = {
             "mv_name": materialized_view.get("table"),

--- a/dbt/adapters/redshift/relation_configs/sort.py
+++ b/dbt/adapters/redshift/relation_configs/sort.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from dbt.adapters.contracts.relation import RelationConfig
-from typing import Optional, FrozenSet, Set, Dict, Any
+from typing import Optional, FrozenSet, Set, Dict, Any, TYPE_CHECKING
 
-import agate
 from dbt.adapters.relation_configs import (
     RelationConfigChange,
     RelationConfigChangeAction,
@@ -14,6 +13,9 @@ from dbt_common.exceptions import DbtRuntimeError
 from typing_extensions import Self
 
 from dbt.adapters.redshift.relation_configs.base import RedshiftRelationConfigBase
+
+if TYPE_CHECKING:
+    import agate
 
 
 class RedshiftSortStyle(StrEnum):
@@ -136,7 +138,7 @@ class RedshiftSortConfig(RedshiftRelationConfigBase, RelationConfigValidationMix
         return config_dict
 
     @classmethod
-    def parse_relation_results(cls, relation_results_entry: agate.Row) -> dict:
+    def parse_relation_results(cls, relation_results_entry: "agate.Row") -> dict:
         """
         Translate agate objects from the database into a standard dictionary.
 


### PR DESCRIPTION
resolves #745

### Problem

TLDR: lazy-loading `agate` speeds up the load time of dbt by about 3.5%. Most instances of `agate` are unnecessary as dbt only uses it in a select few situations, and most instances of `agate` can be placed behind `TYPE_CHECKING`.

Already implemented in `dbt-adapters` and `dbt-core`.

- https://github.com/dbt-labs/dbt-adapters/pull/126
- https://github.com/dbt-labs/dbt-core/pull/9744

Check performed (should return empty list):

```python
import sys
import dbt.adapters.redshift.impl
print([i for i in sys.modules if "agate" in i])
```

### Solution

`from typing import TYPE_CHECKING`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
