### PR TITLE
update sqlparse to be in line with dbt-core 

### DIFF
--- a/.changes/unreleased/Dependencies-20240416-195919.yaml
+++ b/.changes/unreleased/Dependencies-20240416-195919.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: update sqlparse pinned dependency
+time: 2024-04-16T19:59:19.233806-05:00
+custom:
+  Author: McKnight-42
+  PR: "768"

--- a/.changes/unreleased/Dependencies-20240416-195919.yaml
+++ b/.changes/unreleased/Dependencies-20240416-195919.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: update sqlparse pinned dependency
-time: 2024-04-16T19:59:19.233806-05:00
-custom:
-  Author: McKnight-42
-  PR: "768"

--- a/.changes/unreleased/Security-20240416-195919.yaml
+++ b/.changes/unreleased/Security-20240416-195919.yaml
@@ -1,5 +1,5 @@
 kind: Security
-body: update sqlparse pinned dependency and addres security concern GHSA-2m57-hf25-phgg along with dbt-core
+body: Bump sqlparse to >=0.5.0, <0.6.0 to address GHSA-2m57-hf25-phgg along with dbt-core
 time: 2024-04-16T19:59:19.233806-05:00
 custom:
   Author: McKnight-42

--- a/.changes/unreleased/Security-20240416-195919.yaml
+++ b/.changes/unreleased/Security-20240416-195919.yaml
@@ -1,0 +1,6 @@
+kind: Security
+body: update sqlparse pinned dependency and addres security concern GHSA-2m57-hf25-phgg along with dbt-core
+time: 2024-04-16T19:59:19.233806-05:00
+custom:
+  Author: McKnight-42
+  PR: "768"

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0a1",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
-        "sqlparse>=0.5.0,<0.6.0",
+        "sqlparse>=0.2.3,<0.6.0",
         "agate",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0a1",
+        "dbt-core>=1.8.0b3",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "sqlparse>=0.2.3,<0.6.0",
         "agate",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0b3",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
-        "sqlparse>=0.2.3,<0.6.0",
+        "sqlparse>=0.5.0,<0.6.0",
         "agate",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0b3",
+        "dbt-core>=1.8.0a1",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "sqlparse>=0.2.3,<0.6.0",
         "agate",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0a1",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
-        "sqlparse>=0.2.3,<0.5",
+        "sqlparse>=0.5.0,<0.6.0",
         "agate",
     ],
     zip_safe=False,


### PR DESCRIPTION
resolves #
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem
we pinned sqlparse to not go out of range of dbt-core and they recently upgraded we are raising pin to stay in line

similar issue seen in `dbt-postgres` when migrating tests from that repo back to adapters/core https://github.com/dbt-labs/dbt-core/pull/9951
<!---
  Describe the problem this PR is solving. What is the application state
  before this PR is merged?
-->

### Solution

<!---
  Describe the way this PR solves the above problem. Add as much detail as you
  can to help reviewers understand your changes. Include any alternatives and
  tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
