### PR TITLE
Pin `macos` test runners to `macos-12`

### DIFF
--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -37,7 +37,7 @@ module.exports = ({ context }) => {
 
           if (labels.includes("test macos") || testAllLabel) {
             include.push({
-              os: "macos-latest",
+              os: "macos-12",
               adapter,
               "python-version": pythonVersion,
             });
@@ -70,7 +70,7 @@ module.exports = ({ context }) => {
   // additionally include runs for all adapters, on macos and windows,
   // but only for the default python version
   for (const adapter of supportedAdapters) {
-    for (const operatingSystem of ["windows-latest", "macos-latest"]) {
+    for (const operatingSystem of ["windows-latest", "macos-12"]) {
       include.push({
         os: operatingSystem,
         adapter: adapter,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
### Problem

`macos-latest` now points to `macos-14-arm64`; it used to point to `macos-12`. There is no `py39` nor `py38` on `macos-14-arm64`.

### Solution

Pin to `macos-12` for now and discuss long term options to use `macos-14-arm64`, and CI pinning in general.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
