### PR TITLE
[Backport 1.5.latest] Pin `macos` runners to `macos-12` (#787)

### DIFF
--- a/.github/scripts/integration-test-matrix.js
+++ b/.github/scripts/integration-test-matrix.js
@@ -37,7 +37,7 @@ module.exports = ({ context }) => {
 
           if (labels.includes("test macos") || testAllLabel) {
             include.push({
-              os: "macos-latest",
+              os: "macos-12",
               adapter,
               "python-version": pythonVersion,
             });
@@ -70,7 +70,7 @@ module.exports = ({ context }) => {
   // additionally include runs for all adapters, on macos and windows,
   // but only for the default python version
   for (const adapter of supportedAdapters) {
-    for (const operatingSystem of ["windows-latest", "macos-latest"]) {
+    for (const operatingSystem of ["windows-latest", "macos-12"]) {
       include.push({
         os: operatingSystem,
         adapter: adapter,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
(cherry picked from commit ddfc36c3806ab0e370bda68a4b84b45143516b03)

Backport #787