### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.changes/unreleased/Dependencies-20240412-155549.yaml
+++ b/.changes/unreleased/Dependencies-20240412-155549.yaml
@@ -1,6 +1,0 @@
-kind: "Dependencies"
-body: "Bump actions/download-artifact from 3 to 4"
-time: 2024-04-12T15:55:49.00000Z
-custom:
-  Author: dependabot[bot]
-  PR: 765

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,7 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip --version
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Reverts dbt-labs/dbt-redshift#765

The new version of download-artifact is not compatible with the old version of upload-artifact.