### PR TITLE
Fix macos runner typo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, macos12, windows-2022]
+        os: [ubuntu-22.04, macos-12, windows-2022]
         python-version: ["3.8"]
         include:
           - os: ubuntu-22.04


### PR DESCRIPTION
### Problem

We're not referencing the macos runner correctly (`macos12` instead of `macos-12`).

### Solution

Fix it.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
