### PR TITLE
Bump deps on common, adapters, core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,14 +59,14 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-common>=1.0.4,<2.0",
+        "dbt-adapters>=1.1.1,<2.0",
         f"dbt-postgres~={_plugin_version_trim()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0b3",
+        "dbt-core>=1.8.0",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "sqlparse>=0.5.0,<0.6.0",
         "agate",


### PR DESCRIPTION
Bump requirements to:
- `"dbt-common>=1.0.4,<2.0"`
- `"dbt-adapters>=1.1.1,<2.0"`
- `"dbt-core>=1.8.0"`

This way, if someone runs `pip install dbt-redshift` with an existing (v1.8 prerelease) install of the other packages, they won't end up with incompatible package versions.