### PR TITLE
Pin to 2.1.1 and below to fix the cursor error.

### DIFF
--- a/.changes/unreleased/Fixes-20240612-131752.yaml
+++ b/.changes/unreleased/Fixes-20240612-131752.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: update pin range for redshift-connector to allow 2.1.0
+time: 2024-06-12T13:17:52.460407-07:00
+custom:
+  Author: colin-rogers-dbt VersusFacit
+  Issue: "844"

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         f"dbt-postgres~={_plugin_version_trim()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-        "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
+        "redshift-connector<=2.1.1",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0b3",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         f"dbt-postgres~={_plugin_version_trim()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
-        "redshift-connector<=2.1.1",
+        "redshift-connector<2.1.1,>=2.0.913,!=2.0.914",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
         "dbt-core>=1.8.0b3",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core


### PR DESCRIPTION

### Problem
We want to fold in the fix from [this patched issue on redshift connector](https://github.com/aws/amazon-redshift-python-driver/issues/204).

### Solution
Up the pin. soft pinned since either patch version in `2.1` should work

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
