### PR TITLE
remove calculated version for dbt-postgres dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import re
 import sys
 
 if sys.version_info < (3, 8):
@@ -37,16 +36,6 @@ def _plugin_version() -> str:
     return attributes["version"]
 
 
-def _plugin_version_trim() -> str:
-    """
-    Pull the package version from the main package version file
-    """
-    attributes = {}
-    exec(VERSION.read_text(), attributes)
-    pattern = r"\+build\d+$"
-    return re.sub(pattern, "", attributes["version"])
-
-
 setup(
     name="dbt-redshift",
     version=_plugin_version(),
@@ -61,7 +50,7 @@ setup(
     install_requires=[
         "dbt-common>=0.1.0a1,<2.0",
         "dbt-adapters>=0.1.0a1,<2.0",
-        f"dbt-postgres~={_plugin_version_trim()}",
+        "dbt-postgres>=1.8,<1.10",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector<2.1.1,>=2.0.913,!=2.0.914",


### PR DESCRIPTION
### Problem

We calculate the `dbt-postgres` version dependency based on the version of `dbt-redshift`. This causes issues when we want to keep `dbt-postgres` at a different version than `dbt-redshift`.

### Solution

Treat `dbt-postgres` like any other dependency and simply hard code the pin.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
