### PR TITLE
Skip failing test `TestColumnQuotingDefault` on unsupported versions

### DIFF
--- a/tests/integration/column_quoting/test_column_quotes.py
+++ b/tests/integration/column_quoting/test_column_quotes.py
@@ -37,7 +37,7 @@ class TestColumnQuotingDefault(BaseColumnQuotingTest):
     def run_dbt(self, *args, **kwargs):
         return super().run_dbt(*args, **kwargs)
 
-    @pytest.skip("This functionality no longer works as intended and this is an unsupported version.")
+    @pytest.mark.skip("This functionality no longer works as intended and this is an unsupported version.")
     @use_profile('redshift')
     def test_redshift_column_quotes(self):
         self._run_columnn_quotes()

--- a/tests/integration/column_quoting/test_column_quotes.py
+++ b/tests/integration/column_quoting/test_column_quotes.py
@@ -1,6 +1,8 @@
 from tests.integration.base import DBTIntegrationTest,  use_profile
 import os
 
+import pytest
+
 
 class BaseColumnQuotingTest(DBTIntegrationTest):
     def column_quoting(self):
@@ -35,6 +37,7 @@ class TestColumnQuotingDefault(BaseColumnQuotingTest):
     def run_dbt(self, *args, **kwargs):
         return super().run_dbt(*args, **kwargs)
 
+    @pytest.skip("This functionality no longer works as intended and this is an unsupported version.")
     @use_profile('redshift')
     def test_redshift_column_quotes(self):
         self._run_columnn_quotes()


### PR DESCRIPTION
### Problem

The test `tests/integration/column_quoting/test_column_quotes.py::TestColumnQuotingDefault::test_redshift_column_quotes` is consistently failing. While this version is no longer supported, this would block merging anything, such as a security vulnerability patch.

### Solution

Skip the test.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
