### PR TITLE
Pin `setuptools` to address setuptools#4483

### DIFF
--- a/.changes/unreleased/Fixes-20240718-094408.yaml
+++ b/.changes/unreleased/Fixes-20240718-094408.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin `setuptools` to address pypa/setuptools#4483
+time: 2024-07-18T09:44:08.570433-04:00
+custom:
+  Author: mikealfare
+  Issue: "865"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,8 +132,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install  --user --upgrade pip
-          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
-          python -m pip --version
+          python -m pip install -r build-requirements.txt
 
       - name: Build distributions
         run: ./scripts/build-dist.sh

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,5 +1,5 @@
 bumpversion~=0.6.0
 check-wheel-contents~=0.6.0
 setuptools~=70.0
-twine~=4.0
+twine~=5.0
 wheel~=0.42

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,5 @@
+bumpversion~=0.6.0
+check-wheel-contents~=0.6.0
+setuptools~=70.0
+twine~=4.0
+wheel~=0.42

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,6 +21,4 @@ pytest-xdist~=3.5
 tox~=4.11
 
 # build
-bumpversion~=0.6.0
-twine~=4.0
-wheel~=0.42
+-r build-requirements.txt


### PR DESCRIPTION
### Problem

`setuptools` released `71.0.0` and `71.0.1` last night which contains a breaking change. This is blocking our CI. See https://github.com/pypa/setuptools/issues/4483 for more information.

### Solution

- create a separate `build-requirements.txt` file to isolate build dependencies
- pin `setuptools~=70.0` in this file
- reference this file in `dev-requirements.txt` for backwards compatibility
- install from this file in workflows instead of running `pip install --upgrade setuptools ...`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX