### PR TITLE
Remove `freezegun` as a test dependency since it is not used

### DIFF
--- a/.changes/unreleased/Under the Hood-20240719-133151.yaml
+++ b/.changes/unreleased/Under the Hood-20240719-133151.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove `freezegun` as a testing dependency; this package is no longer used
+time: 2024-07-19T13:31:51.503575-04:00
+custom:
+  Author: mikealfare
+  Issue: "1136"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,6 @@ pre-commit==3.5.0;python_version <"3.9"
 
 # test
 ddtrace==2.3.0
-freezegun~=1.4
 pytest~=7.4
 pytest-csv~=3.0
 pytest-dotenv~=0.5.2


### PR DESCRIPTION
### Problem

We list `freezegun` as a test dependency, but it's not used anywhere. It just winds up generating `dependabot` PRs.

### Solution

Remove the dependency. It was left over from the monorepo but does not apply here.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX