### PR TITLE
Adap 821/unit tests infer wrong datatype for None values in fixtures

### DIFF
--- a/.changes/unreleased/Fixes-20240625-170324.yaml
+++ b/.changes/unreleased/Fixes-20240625-170324.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: 'Handle unit test fixtures where typing goes wrong from first value in column
+  being Null. '
+time: 2024-06-25T17:03:24.73937-07:00
+custom:
+  Author: versusfacit
+  Issue: "821"

--- a/dbt/include/redshift/macros/adapters/unit_testing.sql
+++ b/dbt/include/redshift/macros/adapters/unit_testing.sql
@@ -1,0 +1,16 @@
+{% macro redshift__validate_fixture_rows(rows, row_number) %}
+  {%- if items is not none and items|length > 0 -%}
+    {%- set some_value_is_none = false -%}
+    {%- set row = items[0] -%}
+    {%- for key, value in row.items() -%}
+      {%- if value is none -%}
+        {%- set some_value_is_none = true -%}
+      {%- endif -%}
+    {%- endfor -%}
+
+    {%- if some_value_is_none -%}
+      {%- set fixture_name = "expected output" if model.resource_type == 'unit_test' else ("'" ~ model.name ~ "'") -%}
+      {{ exceptions.raise_compiler_error("Unit test fixture " ~ fixture_name ~ " in " ~ model.name ~ " does not have any row free of null values, which may cause type mismatch errors during unit test execution.") }}
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro -%}

--- a/dbt/include/redshift/macros/adapters/unit_testing.sql
+++ b/dbt/include/redshift/macros/adapters/unit_testing.sql
@@ -1,16 +1,11 @@
-{% macro redshift__validate_fixture_rows(rows, row_number) %}
-  {%- if items is not none and items|length > 0 -%}
-    {%- set some_value_is_none = false -%}
-    {%- set row = items[0] -%}
+{%- macro redshift__validate_fixture_rows(rows, row_number) -%}
+  {%- if rows is not none and rows|length > 0 -%}
+    {%- set row = rows[0] -%}
     {%- for key, value in row.items() -%}
       {%- if value is none -%}
-        {%- set some_value_is_none = true -%}
+          {%- set fixture_name = "expected output" if model.resource_type == 'unit_test' else ("'" ~ model.name ~ "'") -%}
+          {{ exceptions.raise_compiler_error("Unit test fixture " ~ fixture_name ~ " in " ~ model.name ~ " does not have any row free of null values, which may cause type mismatch errors during unit test execution.") }}
       {%- endif -%}
     {%- endfor -%}
-
-    {%- if some_value_is_none -%}
-      {%- set fixture_name = "expected output" if model.resource_type == 'unit_test' else ("'" ~ model.name ~ "'") -%}
-      {{ exceptions.raise_compiler_error("Unit test fixture " ~ fixture_name ~ " in " ~ model.name ~ " does not have any row free of null values, which may cause type mismatch errors during unit test execution.") }}
-    {%- endif -%}
   {%- endif -%}
 {%- endmacro -%}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
-git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@support_for_redshift_821#subdirectory=core
 git+https://github.com/dbt-labs/dbt-postgres.git
 
 # dev

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core + dbt-postgres
-git+https://github.com/dbt-labs/dbt-adapters.git
+git+https://github.com/dbt-labs/dbt-adapters.git@ADAP-821/support_for_redshift_821
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core + dbt-postgres
-git+https://github.com/dbt-labs/dbt-adapters.git@ADAP-821/support_for_redshift_821
+git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
-git+https://github.com/dbt-labs/dbt-core.git@support_for_redshift_821#subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 git+https://github.com/dbt-labs/dbt-postgres.git
 
 # dev

--- a/tests/functional/adapter/unit_testing/fixtures.py
+++ b/tests/functional/adapter/unit_testing/fixtures.py
@@ -1,23 +1,23 @@
-model_null_value_base = """
+model_none_value_base = """
 {{ config(materialized="table") }}
 
 select 1 as id, 'a' as col1
 """
 
-model_null_value_model = """
+model_none_value_model = """
 {{config(materialized="table")}}
 
-select * from {{ ref('null_value_base') }}
+select * from {{ ref('none_value_base') }}
 """
 
 
-test_null_column_value_doesnt_throw_error_csv = """
+test_none_column_value_doesnt_throw_error_csv = """
 unit_tests:
   - name: test_simple
 
-    model: null_value_model
+    model: none_value_model
     given:
-      - input: ref('null_value_base')
+      - input: ref('none_value_base')
         format: csv
         rows: |
           id,col1
@@ -34,13 +34,13 @@ unit_tests:
           6,f
 """
 
-test_null_column_value_doesnt_throw_error_dct = """
+test_none_column_value_doesnt_throw_error_dct = """
 unit_tests:
   - name: test_simple
 
-    model: null_value_model
+    model: none_value_model
     given:
-      - input: ref('null_value_base')
+      - input: ref('none_value_base')
         rows:
           - { "id":  , "col1": "d"}
           - { "id":  , "col1": "e"}
@@ -53,13 +53,13 @@ unit_tests:
         - {id: 6, "col1": "f"}
 """
 
-test_null_column_value_will_throw_error = """
+test_none_column_value_will_throw_error = """
 unit_tests:
   - name: test_simple
 
-    model: null_value_model
+    model: none_value_model
     given:
-      - input: ref('null_value_base')
+      - input: ref('none_value_base')
         rows:
           - { "id":  , "col1": "d"}
           - { "id":  , "col1": "e"}

--- a/tests/functional/adapter/unit_testing/fixtures.py
+++ b/tests/functional/adapter/unit_testing/fixtures.py
@@ -10,7 +10,31 @@ model_null_value_model = """
 select * from {{ ref('null_value_base') }}
 """
 
-test_null_column_value_doesnt_throw_error = """
+
+test_null_column_value_doesnt_throw_error_csv = """
+unit_tests:
+  - name: test_simple
+
+    model: null_value_model
+    given:
+      - input: ref('null_value_base')
+        format: csv
+        rows: |
+          id,col1
+          ,d
+          ,e
+          6,f
+
+    expect:
+        format: csv
+        rows: |
+          id,col1
+          ,d
+          ,e
+          6,f
+"""
+
+test_null_column_value_doesnt_throw_error_dct = """
 unit_tests:
   - name: test_simple
 

--- a/tests/functional/adapter/unit_testing/fixtures.py
+++ b/tests/functional/adapter/unit_testing/fixtures.py
@@ -1,0 +1,49 @@
+model_null_value_base = """
+{{ config(materialized="table") }}
+
+select 1 as id, 'a' as col1
+"""
+
+model_null_value_model = """
+{{config(materialized="table")}}
+
+select * from {{ ref('null_value_base') }}
+"""
+
+test_null_column_value_doesnt_throw_error = """
+unit_tests:
+  - name: test_simple
+
+    model: null_value_model
+    given:
+      - input: ref('null_value_base')
+        rows:
+          - { "id":  , "col1": "d"}
+          - { "id":  , "col1": "e"}
+          - { "id": 6, "col1": "f"}
+
+    expect:
+      rows:
+        - {id:  , "col1": "d"}
+        - {id:  , "col1": "e"}
+        - {id: 6, "col1": "f"}
+"""
+
+test_null_column_value_will_throw_error = """
+unit_tests:
+  - name: test_simple
+
+    model: null_value_model
+    given:
+      - input: ref('null_value_base')
+        rows:
+          - { "id":  , "col1": "d"}
+          - { "id":  , "col1": "e"}
+          - { "id": 6, "col1": }
+
+    expect:
+      rows:
+        - {id:  , "col1": "d"}
+        - {id:  , "col1": "e"}
+        - {id: 6, "col1": }
+"""

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -8,11 +8,11 @@ from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestCaseInsensivity
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 from tests.functional.adapter.unit_testing.fixtures import (
-    model_null_value_base,
-    model_null_value_model,
-    test_null_column_value_doesnt_throw_error_csv,
-    test_null_column_value_doesnt_throw_error_dct,
-    test_null_column_value_will_throw_error,
+    model_none_value_base,
+    model_none_value_model,
+    test_none_column_value_doesnt_throw_error_csv,
+    test_none_column_value_doesnt_throw_error_dct,
+    test_none_column_value_will_throw_error,
 )
 
 
@@ -46,45 +46,45 @@ class TestRedshiftUnitTestingTypes(BaseUnitTestingTypes):
         ]
 
 
-class RedshiftUnitTestingNull:
-    def test_nulls_handled_dict(self, project):
+class RedshiftUnitTestingNone:
+    def test_nones_handled_dict(self, project):
         run_dbt(["build"])
 
 
-class TestRedshiftUnitTestCsvNull(RedshiftUnitTestingNull):
+class TestRedshiftUnitTestCsvNone(RedshiftUnitTestingNone):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "null_value_base.sql": model_null_value_base,
-            "null_value_model.sql": model_null_value_model,
-            "__properties.yml": test_null_column_value_doesnt_throw_error_csv,
+            "none_value_base.sql": model_none_value_base,
+            "none_value_model.sql": model_none_value_model,
+            "__properties.yml": test_none_column_value_doesnt_throw_error_csv,
         }
 
 
-class TestRedshiftUnitTestDictNull(RedshiftUnitTestingNull):
+class TestRedshiftUnitTestDictNone(RedshiftUnitTestingNone):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "null_value_base.sql": model_null_value_base,
-            "null_value_model.sql": model_null_value_model,
-            "__properties.yml": test_null_column_value_doesnt_throw_error_dct,
+            "none_value_base.sql": model_none_value_base,
+            "none_value_model.sql": model_none_value_model,
+            "__properties.yml": test_none_column_value_doesnt_throw_error_dct,
         }
 
 
-class TestRedshiftUnitTestingTooManyNullsFails:
+class TestRedshiftUnitTestingTooManyNonesFails:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "__properties.yml": test_null_column_value_will_throw_error,
-            "null_value_base.sql": model_null_value_base,
-            "null_value_model.sql": model_null_value_model,
+            "__properties.yml": test_none_column_value_will_throw_error,
+            "none_value_base.sql": model_none_value_base,
+            "none_value_model.sql": model_none_value_model,
         }
 
     def test_invalid_input(self, project):
         with pytest.raises(ParsingError) as e:
             run_dbt(["build"])
 
-        assert "Unit Test fixtures require at least one row free of Null" in str(e)
+        assert "Unit Test fixtures require at least one row free of None" in str(e)
 
 
 class TestRedshiftUnitTestCaseInsensitivity(BaseUnitTestCaseInsensivity):

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -1,7 +1,18 @@
 import pytest
+
+from dbt.exceptions import ParsingError
+from dbt.tests.fixtures.project import write_project_files
+from dbt.tests.util import run_dbt
+
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestCaseInsensivity
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
+from tests.functional.adapter.unit_testing.fixtures import (
+    model_null_value_base,
+    model_null_value_model,
+    test_null_column_value_doesnt_throw_error,
+    test_null_column_value_will_throw_error,
+)
 
 
 class TestRedshiftUnitTestingTypes(BaseUnitTestingTypes):
@@ -32,6 +43,35 @@ class TestRedshiftUnitTestingTypes(BaseUnitTestingTypes):
             # ["ARRAY[TIMESTAMP '2013-11-03 00:00:00-0']", """'{"2013-11-03 00:00:00-0"}'"""],
             # ["ARRAY[TIMESTAMPTZ '2013-11-03 00:00:00-0']", """'{"2013-11-03 00:00:00-0"}'"""],
         ]
+
+
+class TestRedshiftUnitTestingNull:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "__properties.yml": test_null_column_value_doesnt_throw_error,
+            "null_value_base.sql": model_null_value_base,
+            "null_value_model.sql": model_null_value_model,
+        }
+
+    def test_invalid_input(self, project):
+        run_dbt(["build"])
+
+
+class TestRedshiftUnitTestingTooManyNullsFails:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "__properties.yml": test_null_column_value_will_throw_error,
+            "null_value_base.sql": model_null_value_base,
+            "null_value_model.sql": model_null_value_model,
+        }
+
+    def test_invalid_input(self, project):
+        with pytest.raises(ParsingError) as e:
+            run_dbt(["build"])
+
+        assert "Unit Test fixtures require at least one row free of Null" in str(e)
 
 
 class TestRedshiftUnitTestCaseInsensitivity(BaseUnitTestCaseInsensivity):

--- a/tests/functional/adapter/unit_testing/test_unit_testing.py
+++ b/tests/functional/adapter/unit_testing/test_unit_testing.py
@@ -10,7 +10,8 @@ from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvali
 from tests.functional.adapter.unit_testing.fixtures import (
     model_null_value_base,
     model_null_value_model,
-    test_null_column_value_doesnt_throw_error,
+    test_null_column_value_doesnt_throw_error_csv,
+    test_null_column_value_doesnt_throw_error_dct,
     test_null_column_value_will_throw_error,
 )
 
@@ -45,17 +46,29 @@ class TestRedshiftUnitTestingTypes(BaseUnitTestingTypes):
         ]
 
 
-class TestRedshiftUnitTestingNull:
+class RedshiftUnitTestingNull:
+    def test_nulls_handled_dict(self, project):
+        run_dbt(["build"])
+
+
+class TestRedshiftUnitTestCsvNull(RedshiftUnitTestingNull):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "__properties.yml": test_null_column_value_doesnt_throw_error,
             "null_value_base.sql": model_null_value_base,
             "null_value_model.sql": model_null_value_model,
+            "__properties.yml": test_null_column_value_doesnt_throw_error_csv,
         }
 
-    def test_invalid_input(self, project):
-        run_dbt(["build"])
+
+class TestRedshiftUnitTestDictNull(RedshiftUnitTestingNull):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "null_value_base.sql": model_null_value_base,
+            "null_value_model.sql": model_null_value_model,
+            "__properties.yml": test_null_column_value_doesnt_throw_error_dct,
+        }
 
 
 class TestRedshiftUnitTestingTooManyNullsFails:


### PR DESCRIPTION
resolves #821 

Note this Pr depends on the [base adapter PR here](https://github.com/dbt-labs/dbt-adapters/pull/270).

### Problem

Take 2 in response to #860 

### Solution

Redshift provides a macro that will check for the bad row scenario and throw a more helpful error to the user than the existing type mismatch bug that caused this error in the first place.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX