### PR TITLE
Add `query_id` of last executed statement to Adapter Response

### DIFF
--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -74,7 +74,7 @@ SSL_MODE_TRANSLATION = {
 
 @dataclass
 class RedshiftAdapterResponse(AdapterResponse):
-    query_id: int
+    query_id: int = -1
 
 
 @dataclass
@@ -333,8 +333,8 @@ class RedshiftConnectionManager(SQLConnectionManager):
         message = "SUCCESS"
         query_id = cls._get_last_query_id(cursor)
         return RedshiftAdapterResponse(
-            _message=message, 
-            rows_affected=rows, 
+            _message=message,
+            rows_affected=rows,
             query_id=query_id,
         )
 


### PR DESCRIPTION
resolves dbt-labs/dbt-adapters#630
[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.

  Include the number of the docs issue that was opened for this PR. If
  this change has no user-facing implications, "N/A" suffices instead. New
  docs tickets can be created by clicking the link above or by going to
  https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose.
-->

### Problem

I want to be able to capture the `query_id` of the statement used to load a model.

### Solution

I ripped this off of the dbt-snowflake adapter and how they are setting `query_id` on the adapter response:

https://github.com/dbt-labs/dbt-snowflake/blob/f95b9192f6eec9af4e30eaab87f9e3412febf7d1/dbt/adapters/snowflake/connections.py#L456-L461

I realize it is different from Snowflake in that appears that the query ID is available directly on the `cursor` object, and with Redshift you need to use the `pg_last_query_id()` function in order to get the query ID.

I'm sure this doesn't handle 100% of accurately capturing the correct query ID for a particular load (I'm sure there are cases where multiple statements are run in order to perform the model or snapshot load), but I think this is a good start.

Please let me know what I'm missing here in the potential of this breaking something else due to injecting another another query into a model load flow.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
