### PR TITLE
Remove 1.8.latest core reference from install.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/dbt-labs/dbt-adapters.git
 git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
-git+https://github.com/dbt-labs/dbt-core.git@1.8.latest#subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 git+https://github.com/dbt-labs/dbt-postgres.git@1.8.latest
 
 # dev


### PR DESCRIPTION

### Problem

```
 syntax error at or near "'foreign_key_model'" in context "key references ref('foreign_key_model'", at line 9, column 52
  compiled Code at target/run/test/models/my_model.sql
```

This is related to a similar snowflake issue https://github.com/dbt-labs/dbt-snowflake/pull/1150/files

### Solution

Get rid of the branch reference.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX