### PR TITLE
Use `redshift_connector`'s `get_columns` call to get column metadata

### DIFF
--- a/.changes/unreleased/Features-20240826-123954.yaml
+++ b/.changes/unreleased/Features-20240826-123954.yaml
@@ -2,5 +2,5 @@ kind: Features
 body: Remove `pg_catalog` from metadata queries
 time: 2024-08-26T12:39:54.481505-04:00
 custom:
-  Author: mikealfare
+  Author: mikealfare, jiezhen-chen
   Issue: "555"

--- a/.changes/unreleased/Features-20240826-123954.yaml
+++ b/.changes/unreleased/Features-20240826-123954.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Remove `pg_catalog` from metadata queries
+time: 2024-08-26T12:39:54.481505-04:00
+custom:
+  Author: mikealfare
+  Issue: "555"

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -483,7 +483,7 @@ class RedshiftConnectionManager(SQLConnectionManager):
         columns = cursor.get_columns(
             catalog=relation.database,
             schema_pattern=relation.schema,
-            table_name_pattern=relation.identifier,
+            tablename_pattern=relation.identifier,
         )
 
         fire_event(
@@ -498,10 +498,19 @@ class RedshiftConnectionManager(SQLConnectionManager):
 
     @staticmethod
     def _parse_column_results(record: Tuple[Any, ...]) -> Dict[str, Any]:
+        # column positions in the tuple
+        column_name = 3
+        dtype_code = 4
+        dtype_name = 5
+        column_size = 6
+        decimals = 8
+
+        char_dtypes = [1, 12]
+        num_dtypes = [2, 3, 4, 5, 6, 7, 8]
         return {
-            "column": record[3],
-            "dtype": record[6],
-            "char_size": record[7] if record[5] in [1, 12] else None,
-            "numeric_precision": record[7] if record[5] in [2, 3, 4, 5, 6, 7, 8] else None,
-            "numeric_scale": record[9] if record[5] in [2, 3, 4, 5, 6, 7, 8] else None,
+            "column": record[column_name],
+            "dtype": record[dtype_name],
+            "char_size": record[column_size] if record[dtype_code] in char_dtypes else None,
+            "numeric_precision": record[column_size] if record[dtype_code] in num_dtypes else None,
+            "numeric_scale": record[decimals] if record[dtype_code] in num_dtypes else None,
         }

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -472,7 +472,7 @@ class RedshiftConnectionManager(SQLConnectionManager):
         fire_event(
             SQLQuery(
                 conn_name=cast_to_str(connection.name),
-                sql=f"get_columns_in_relation: {relation.render()}",
+                sql=f"call redshift_connector.Connection.get_columns({relation.database}, {relation.schema}, {relation.identifier})",
                 node_info=get_node_info(),
             )
         )

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -498,19 +498,18 @@ class RedshiftConnectionManager(SQLConnectionManager):
 
     @staticmethod
     def _parse_column_results(record: Tuple[Any, ...]) -> Dict[str, Any]:
-        # column positions in the tuple
-        column_name = 3
-        dtype_code = 4
-        dtype_name = 5
-        column_size = 6
-        decimals = 8
+        _, _, _, column_name, dtype_code, dtype_name, column_size, _, decimals, *_ = record
 
         char_dtypes = [1, 12]
-        num_dtypes = [2, 3, 4, 5, 6, 7, 8]
-        return {
-            "column": record[column_name],
-            "dtype": record[dtype_name],
-            "char_size": record[column_size] if record[dtype_code] in char_dtypes else None,
-            "numeric_precision": record[column_size] if record[dtype_code] in num_dtypes else None,
-            "numeric_scale": record[decimals] if record[dtype_code] in num_dtypes else None,
-        }
+        num_dtypes = [2, 3, 4, 5, 6, 7, 8, -5, 2003]
+
+        if dtype_code in char_dtypes:
+            return {"column": column_name, "dtype": dtype_name, "char_size": column_size}
+        elif dtype_code in num_dtypes:
+            return {
+                "column": column_name,
+                "dtype": dtype_name,
+                "numeric_precision": column_size,
+                "numeric_scale": decimals,
+            }
+        return {"column": column_name, "dtype": dtype_name, "char_size": column_size}

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -1,7 +1,9 @@
 import os
 from dataclasses import dataclass
+
+from dbt_common.behavior_flags import BehaviorFlag
 from dbt_common.contracts.constraints import ConstraintType
-from typing import Optional, Set, Any, Dict, Type, TYPE_CHECKING
+from typing import Optional, Set, Any, Dict, Type, TYPE_CHECKING, List
 from collections import namedtuple
 from dbt.adapters.base import PythonJobHelper
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
@@ -64,6 +66,10 @@ class RedshiftAdapter(SQLAdapter):
             Capability.TableLastModifiedMetadataBatch: CapabilitySupport(support=Support.Full),
         }
     )
+
+    @property
+    def _behavior_extra(self) -> List[BehaviorFlag]:
+        return [{"name": "restrict_access_to_pg_catalog", "default": False}]
 
     @classmethod
     def date_function(cls):

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -70,7 +70,7 @@ class RedshiftAdapter(SQLAdapter):
 
     @property
     def _behavior_flags(self) -> List[BehaviorFlag]:
-        return [{"name": "retire_pg_catalog", "default": False}]
+        return [{"name": "restrict_direct_pg_catalog_access", "default": False}]
 
     @classmethod
     def date_function(cls):
@@ -95,7 +95,7 @@ class RedshiftAdapter(SQLAdapter):
             return super().drop_relation(relation)
 
     def get_columns_in_relation(self, relation) -> List[Column]:
-        if self.behavior.retire_pg_catalog:
+        if self.behavior.restrict_direct_pg_catalog_access:
             column_configs = self.connections.columns_in_relation(relation)
             return [Column(**column) for column in column_configs]
         return super().get_columns_in_relation(relation)

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -6,6 +6,7 @@ from dbt_common.contracts.constraints import ConstraintType
 from typing import Optional, Set, Any, Dict, Type, TYPE_CHECKING, List
 from collections import namedtuple
 from dbt.adapters.base import PythonJobHelper
+from dbt.adapters.base.column import Column
 from dbt.adapters.base.impl import AdapterConfig, ConstraintSupport
 from dbt.adapters.base.meta import available
 from dbt.adapters.capability import Capability, CapabilityDict, CapabilitySupport, Support
@@ -92,6 +93,12 @@ class RedshiftAdapter(SQLAdapter):
         """
         with self.connections.fresh_transaction():
             return super().drop_relation(relation)
+
+    def get_columns_in_relation(self, relation) -> List[Column]:
+        if self.behavior.retire_pg_catalog:
+            column_configs = self.connections.columns_in_relation(relation)
+            return [Column(**column) for column in column_configs]
+        return super().get_columns_in_relation(relation)
 
     @classmethod
     def convert_text_type(cls, agate_table: "agate.Table", col_idx):

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -69,7 +69,7 @@ class RedshiftAdapter(SQLAdapter):
 
     @property
     def _behavior_extra(self) -> List[BehaviorFlag]:
-        return [{"name": "restrict_access_to_pg_catalog", "default": False}]
+        return [{"name": "retire_pg_catalog", "default": False}]
 
     @classmethod
     def date_function(cls):

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -69,7 +69,7 @@ class RedshiftAdapter(SQLAdapter):
     )
 
     @property
-    def _behavior_extra(self) -> List[BehaviorFlag]:
+    def _behavior_flags(self) -> List[BehaviorFlag]:
         return [{"name": "retire_pg_catalog", "default": False}]
 
     @classmethod

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # install latest changes in dbt-core + dbt-postgres
 git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags
-git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-adapters.git
+git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git
 git+https://github.com/dbt-labs/dbt-postgres.git
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core + dbt-postgres
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@behavior-flags#subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git@behavior-flags

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # install latest changes in dbt-core + dbt-postgres
-git+https://github.com/dbt-labs/dbt-core.git@behavior-flags#subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags#subdirectory=dbt-tests-adapter
 git+https://github.com/dbt-labs/dbt-common.git

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/dbt-labs/dbt-core.git@behavior-flags#subdirectory=core
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags
 git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags#subdirectory=dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-common.git@behavior-flags
+git+https://github.com/dbt-labs/dbt-common.git
 git+https://github.com/dbt-labs/dbt-postgres.git
 
 # dev

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
 # install latest changes in dbt-core + dbt-postgres
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
-git+https://github.com/dbt-labs/dbt-common.git
+git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags
+git+https://github.com/dbt-labs/dbt-adapters.git@behavior-flags#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-common.git@behavior-flags
 git+https://github.com/dbt-labs/dbt-postgres.git
 
 # dev

--- a/tests/boundary/conftest.py
+++ b/tests/boundary/conftest.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+import os
+import random
+
+import pytest
+import redshift_connector
+
+
+@pytest.fixture
+def connection() -> redshift_connector.Connection:
+    return redshift_connector.connect(
+        user=os.getenv("REDSHIFT_TEST_USER"),
+        password=os.getenv("REDSHIFT_TEST_PASS"),
+        host=os.getenv("REDSHIFT_TEST_HOST"),
+        port=int(os.getenv("REDSHIFT_TEST_PORT")),
+        database=os.getenv("REDSHIFT_TEST_DBNAME"),
+        region=os.getenv("REDSHIFT_TEST_REGION"),
+    )
+
+
+@pytest.fixture
+def schema_name(request) -> str:
+    runtime = datetime.utcnow() - datetime(1970, 1, 1, 0, 0, 0)
+    runtime_s = int(runtime.total_seconds())
+    runtime_ms = runtime.microseconds
+    random_int = random.randint(0, 9999)
+    file_name = request.module.__name__.split(".")[-1]
+    return f"test_{runtime_s}{runtime_ms}{random_int:04}_{file_name}"

--- a/tests/boundary/test_redshift_connector.py
+++ b/tests/boundary/test_redshift_connector.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.fixture
+def schema(connection, schema_name) -> str:
+    with connection.cursor() as cursor:
+        cursor.execute(f"CREATE SCHEMA IF NOT EXISTS {schema_name}")
+    yield schema_name
+    with connection.cursor() as cursor:
+        cursor.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+
+
+def test_columns_in_relation(connection, schema):
+    table = "cross_db"
+    with connection.cursor() as cursor:
+        cursor.execute(f"CREATE TABLE {schema}.{table} as select 3.14 as id")
+        columns = cursor.get_columns(
+            schema_pattern=schema,
+            tablename_pattern=table,
+        )
+
+    assert len(columns) == 1
+    column = columns[0]
+
+    (
+        database_name,
+        schema_name,
+        table_name,
+        column_name,
+        type_code,
+        type_name,
+        precision,
+        _,
+        scale,
+        *_,
+    ) = column
+    assert schema_name == schema
+    assert table_name == table
+    assert column_name == "id"
+    assert type_code == 2
+    assert type_name == "numeric"
+    assert precision == 3
+    assert scale == 2

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+# supports namespacing during test discovery

--- a/tests/functional/test_columns_in_relation.py
+++ b/tests/functional/test_columns_in_relation.py
@@ -48,7 +48,7 @@ class TestColumnsInRelationBehaviorFlagOff(ColumnsInRelation):
 class TestColumnsInRelationBehaviorFlagOn(ColumnsInRelation):
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {"flags": {"retire_pg_catalog": True}}
+        return {"flags": {"restrict_direct_pg_catalog_access": True}}
 
     @pytest.fixture(scope="class")
     def expected_columns(self):

--- a/tests/functional/test_columns_in_relation.py
+++ b/tests/functional/test_columns_in_relation.py
@@ -1,0 +1,59 @@
+from dbt.adapters.base import Column
+from dbt.tests.util import run_dbt
+import pytest
+
+from dbt.adapters.redshift import RedshiftRelation
+
+
+class ColumnsInRelation:
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model.sql": "select 1.23 as my_num, 'a' as my_char"}
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, project):
+        run_dbt(["run"])
+
+    @pytest.fixture(scope="class")
+    def expected_columns(self):
+        return []
+
+    def test_columns_in_relation(self, project, expected_columns):
+        my_relation = RedshiftRelation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="my_model",
+            type=RedshiftRelation.View,
+        )
+        with project.adapter.connection_named("_test"):
+            actual_columns = project.adapter.get_columns_in_relation(my_relation)
+        assert actual_columns == expected_columns
+
+
+class TestColumnsInRelationBehaviorFlagOff(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {}}
+
+    @pytest.fixture(scope="class")
+    def expected_columns(self):
+        # the SDK query returns "varchar" whereas our custom query returns "character varying"
+        return [
+            Column(column="my_num", dtype="numeric", numeric_precision=3, numeric_scale=2),
+            Column(column="my_char", dtype="character varying", char_size=1),
+        ]
+
+
+class TestColumnsInRelationBehaviorFlagOn(ColumnsInRelation):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"flags": {"retire_pg_catalog": True}}
+
+    @pytest.fixture(scope="class")
+    def expected_columns(self):
+        # the SDK query returns "varchar" whereas our custom query returns "character varying"
+        return [
+            Column(column="my_num", dtype="numeric", numeric_precision=3, numeric_scale=2),
+            Column(column="my_char", dtype="varchar", char_size=1),
+        ]


### PR DESCRIPTION
resolves #555

### Problem

`dbt-redshift` references `pg_catalog` tables in its metadata queries. It should rely on Redshift's SDK or `information_schema` tables.

### Solution

- Retire references to `pg_catalog` behind a behavior flag
- Move to SDK calls when possible
- Fall back on SQL calls that avoid referencing `pg_catalog`

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
