### PR TITLE
Add cascade to drop mv

### DIFF
--- a/.changes/unreleased/Fixes-20240906-102642.yaml
+++ b/.changes/unreleased/Fixes-20240906-102642.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Support DROP CASCADE for materialized views; fixes bug that occurs when running
+  dbt on materialized views that reference other materialized views
+time: 2024-09-06T10:26:42.501014-04:00
+custom:
+  Author: mikealfare
+  Issue: "642"

--- a/dbt/include/redshift/macros/relations/materialized_view/drop.sql
+++ b/dbt/include/redshift/macros/relations/materialized_view/drop.sql
@@ -1,3 +1,3 @@
 {% macro redshift__drop_materialized_view(relation) -%}
-    drop materialized view if exists {{ relation }}
+    drop materialized view if exists {{ relation }} cascade
 {%- endmacro %}

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+# provides namespacing for test discovery

--- a/tests/functional/adapter/__init__.py
+++ b/tests/functional/adapter/__init__.py
@@ -1,0 +1,1 @@
+# provides namespacing for test discovery

--- a/tests/functional/adapter/materialized_view_tests/__init__.py
+++ b/tests/functional/adapter/materialized_view_tests/__init__.py
@@ -1,0 +1,1 @@
+# provides namespacing for test discovery

--- a/tests/functional/adapter/materialized_view_tests/test_drop_cascade.py
+++ b/tests/functional/adapter/materialized_view_tests/test_drop_cascade.py
@@ -1,0 +1,56 @@
+"""
+This test addresses this bug: https://github.com/dbt-labs/dbt-redshift/issues/642
+
+Redshift did not initially support DROP CASCADE for materialized views,
+or at least did not document that they did. Now that they do, we should
+use DROP CASCADE instead of DROP.
+"""
+
+from dbt.tests.util import run_dbt
+import pytest
+
+
+SEED = """
+id
+1
+""".strip()
+
+
+PARENT_MATERIALIZED_VIEW = """
+{{ config(
+    materialized='materialized_view',
+    on_configuration_change='apply',
+) }}
+
+select * from {{ ref('my_seed') }}
+"""
+
+
+CHILD_MATERIALIZED_VIEW = """
+{{ config(
+    materialized='materialized_view',
+    on_configuration_change='apply',
+) }}
+
+select * from {{ ref('parent_mv') }}
+"""
+
+
+@pytest.fixture(scope="class")
+def seeds():
+    return {"my_seed.csv": SEED}
+
+
+@pytest.fixture(scope="class")
+def models():
+    return {
+        "parent_mv.sql": PARENT_MATERIALIZED_VIEW,
+        "child_mv.sql": CHILD_MATERIALIZED_VIEW,
+    }
+
+
+def test_drop_cascade(project):
+    run_dbt(["seed"])
+    run_dbt(["run"])
+    # this originally raised an error when it should not have
+    run_dbt(["run", "--full-refresh"])


### PR DESCRIPTION
resolves #642

### Problem

We drop materialized views with a standard `DROP` instead of a `DROP ... CASCADE`. When a dbt project has materialized views that reference other materialized views, the materialized view cannot be dropped during a full refresh. This raises a database error.

### Solution

Update the `DROP` statement to a `DROP ... CASCADE` statement.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
