### PR TITLE
Isolating distribution testing

### DIFF
--- a/.changes/unreleased/Under the Hood-20240911-192855.yaml
+++ b/.changes/unreleased/Under the Hood-20240911-192855.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Isolating distribution testing
+time: 2024-09-11T19:28:55.992897-04:00
+custom:
+    Author: leahwicz
+    Issue: "874"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -83,7 +83,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
 
@@ -156,13 +156,13 @@ jobs:
           if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
           echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
 
   test-build:
-    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }}
+    name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.dist-type }}
 
     if: needs.build.outputs.is_alpha == 0
 
@@ -173,22 +173,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        dist-type: ['whl', 'gz']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install python dependencies
         run: |
-          python -m pip install  --user --upgrade pip
+          python -m pip install --user --upgrade pip
           python -m pip install --upgrade wheel
           python -m pip --version
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -196,18 +197,10 @@ jobs:
       - name: Show distributions
         run: ls -lh dist/
 
-      - name: Install wheel distributions
+      - name: Install ${{ matrix.dist-type }} distributions
         run: |
-          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+          find ./dist/*.${{ matrix.dist-type }} -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
 
-      - name: Check wheel distributions
-        run: |
-          python -c "import dbt.adapters.redshift"
-
-      - name: Install source distributions
-        run: |
-          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: Check source distributions
+      - name: Check ${{ matrix.dist-type }} distributions
         run: |
           python -c "import dbt.adapters.redshift"


### PR DESCRIPTION
resolves #874  

### Problem
We validate wheel and source distributions in the same environment during the build validation step. This led to issues documented here https://github.com/dbt-labs/dbt-core/issues/10465. 

### Solution
This is the same solution as what we did in `dbt-snowflake` first: https://github.com/dbt-labs/dbt-snowflake/pull/1161
This is to bring parity to the other repos as well.

This is a test run of the Action running with the installation and testing of wheels and source distributions split into separate Actions Jobs that isolate them from one another: https://github.com/leahwicz/dbt-redshift/actions/runs/10821351505

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
