### PR TITLE
Add microbatch strategy

### DIFF
--- a/.changes/unreleased/Features-20241002-171112.yaml
+++ b/.changes/unreleased/Features-20241002-171112.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add microbatch strategy
+time: 2024-10-02T17:11:12.88725-05:00
+custom:
+  Author: QMalcolm
+  Issue: "923"

--- a/dbt/adapters/redshift/impl.py
+++ b/dbt/adapters/redshift/impl.py
@@ -155,7 +155,7 @@ class RedshiftAdapter(SQLAdapter):
         """The set of standard builtin strategies which this adapter supports out-of-the-box.
         Not used to validate custom strategies defined by end users.
         """
-        return ["append", "delete+insert", "merge"]
+        return ["append", "delete+insert", "merge", "microbatch"]
 
     def timestamp_add_sql(self, add_to: str, number: int = 1, interval: str = "hour") -> str:
         return f"{add_to} + interval '{number} {interval}'"

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -67,6 +67,12 @@
 {% endmacro %}
 
 {% macro redshift__get_incremental_microbatch_sql(arg_dict) %}
+    {#-
+        Technically this function could just call out to the default implementation of delete_insert.
+        However, the default implementation requires a unique_id, which we actually do not want or
+        need. Thus we re-implement delete insert here without the unique_id requirement
+    -#}
+
     {%- set target = arg_dict["target_relation"] -%}
     {%- set source = arg_dict["temp_relation"] -%}
     {%- set dest_columns = arg_dict["dest_columns"] -%}

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -99,13 +99,11 @@
     {% do arg_dict.update({'incremental_predicates': predicates}) %}
 
     delete from {{ target }}
-    {% if predicates | length > 0 %}
-        where (
-        {% for predicate in predicates %}
-            {%- if not loop.first %}and {% endif -%} {{ predicate }}
-        {% endfor %}
-        );
-    {% endif %}
+    where (
+    {% for predicate in predicates %}
+        {%- if not loop.first %}and {% endif -%} {{ predicate }}
+    {% endfor %}
+    );
 
     {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
     insert into {{ target }} ({{ dest_cols_csv }})

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -65,3 +65,34 @@
     )
 
 {% endmacro %}
+
+{% macro redshift__get_incremental_microbatch_sql(arg_dict) %}
+    {%- set target = arg_dict["target_relation"] -%}
+    {%- set source = arg_dict["temp_relation"] -%}
+    {%- set dest_columns = arg_dict["dest_columns"] -%}
+    {%- set incremental_predicates = [] if arg_dict.get('incremental_predicates') is none else arg_dict.get('incremental_predicates') -%}
+
+    {#-- Add additional incremental_predicates to filter for batch --#}
+    {% if model.config.get("__dbt_internal_microbatch_event_time_start") -%}
+        {% do incremental_predicates.append("DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " >= TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "'") %}
+    {% endif %}
+    {% if model.config.__dbt_internal_microbatch_event_time_end -%}
+        {% do incremental_predicates.append("DBT_INTERNAL_TARGET." ~ model.config.event_time ~ " < TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "'") %}
+    {% endif %}
+    {% do arg_dict.update({'incremental_predicates': incremental_predicates}) %}
+
+    delete from {{ target }} DBT_INTERNAL_TARGET
+    using {{ source }}
+    where (
+    {% for predicate in incremental_predicates %}
+        {%- if not loop.first %}and {% endif -%} {{ predicate }}
+    {% endfor %}
+    );
+
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+    insert into {{ target }} ({{ dest_cols_csv }})
+    (
+        select {{ dest_cols_csv }}
+        from {{ source }}
+    )
+{% endmacro %}

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -94,8 +94,8 @@
     {% endif %}
 
     {#-- Add additional incremental_predicates to filter for batch --#}
-    {% do predicates.append(target ~ "." ~ model.config.event_time ~ " >= TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "'") %}
-    {% do predicates.append(target ~ "." ~ model.config.event_time ~ " < TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "'") %}
+    {% do predicates.append(model.config.event_time ~ " >= TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "'") %}
+    {% do predicates.append(model.config.event_time ~ " < TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "'") %}
     {% do arg_dict.update({'incremental_predicates': predicates}) %}
 
     delete from {{ target }}

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -89,7 +89,7 @@
         {% do predicates.append(pred) %}
     {% endfor %}
 
-    {% if not model.config.get("__dbt_internal_microbatch_event_time_start") or not model.config.__dbt_internal_microbatch_event_time_end -%}
+    {% if not model.config.get("__dbt_internal_microbatch_event_time_start") or not model.config.get("__dbt_internal_microbatch_event_time_end") -%}
         {% do exceptions.raise_compiler_error('dbt could not compute the start and end timestamps for the running batch') %}
     {% endif %}
 

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -6,7 +6,7 @@ from dbt.tests.adapter.incremental.test_incremental_microbatch import (
 
 # No requirement for a unique_id for redshift microbatch!
 _microbatch_model_no_unique_id_sql = """
-{{ config(materialized='incremental', incremental_strategy='microbatch', event_time='event_time', batch_size='day') }}
+{{ config(materialized='incremental', incremental_strategy='microbatch', event_time='event_time', batch_size='day', begin=modules.datetime.datetime(2020, 1, 1, 0, 0, 0)) }}
 select * from {{ ref('input_model') }}
 """
 

--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -1,0 +1,24 @@
+import pytest
+from dbt.tests.adapter.incremental.test_incremental_microbatch import (
+    BaseMicrobatch,
+)
+
+
+# No requirement for a unique_id for redshift microbatch!
+_microbatch_model_no_unique_id_sql = """
+{{ config(materialized='incremental', incremental_strategy='microbatch', event_time='event_time', batch_size='day') }}
+select * from {{ ref('input_model') }}
+"""
+
+
+class TestSnowflakeMicrobatch(BaseMicrobatch):
+    @pytest.fixture(scope="class")
+    def microbatch_model_sql(self) -> str:
+        return _microbatch_model_no_unique_id_sql
+
+    @pytest.fixture(scope="class")
+    def insert_two_rows_sql(self, project) -> str:
+        test_schema_relation = project.adapter.Relation.create(
+            database=project.database, schema=project.test_schema
+        )
+        return f"insert into {test_schema_relation}.input_model (id, event_time) values (4, '2020-01-04 00:00:00-0'), (5, '2020-01-05 00:00:00-0')"


### PR DESCRIPTION
resolves #923

### Problem

dbt-redshift needs a microbatch implementation that: 
* efficiently inserts new batches of data knowing that `compiled_code` will be filtered down by event_time
* does not require a `unique_key` configuration on the model.

### Solution

We did a custom implementation of delete+insert specifically for microbatch

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
