### PR TITLE
Update adapter so temporary tables are not created when foreign keys

### DIFF
--- a/.changes/unreleased/Fixes-20241011-103317.yaml
+++ b/.changes/unreleased/Fixes-20241011-103317.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Foreign key constraint on incremental model results in Database Error
+time: 2024-10-11T10:33:17.860744-04:00
+custom:
+    Author: bdgeise
+    Issue: "628"

--- a/dbt/include/redshift/macros/adapters.sql
+++ b/dbt/include/redshift/macros/adapters.sql
@@ -42,37 +42,28 @@
   {%- set backup = config.get('backup') -%}
 
   {{ sql_header if sql_header is not none }}
+  create {% if temporary -%}temporary{%- endif %} table
+    {{ relation.include(database=(not temporary), schema=(not temporary)) }}
+    {% if backup == false -%}backup no{%- endif %}
+    {{ dist(_dist) }}
+    {{ sort(_sort_type, _sort) }}
 
   {%- set contract_config = config.get('contract') -%}
   {%- if contract_config.enforced -%}
-
-  create {% if temporary -%}temporary{%- endif %} table
-    {{ relation.include(database=(not temporary), schema=(not temporary)) }}
-    {{ get_table_columns_and_constraints() }}
     {{ get_assert_columns_equivalent(sql) }}
-    {%- set sql = get_select_subquery(sql) %}
-    {% if backup == false -%}backup no{%- endif %}
-    {{ dist(_dist) }}
-    {{ sort(_sort_type, _sort) }}
-  ;
-
-  insert into {{ relation.include(database=(not temporary), schema=(not temporary)) }}
-    (
-      {{ sql }}
-    )
-  ;
-
+  {% endif -%}
+  {% if contract_config.enforced and (not temporary) -%}
+	{{ get_table_columns_and_constraints() }};
+	{%- set sql = get_select_subquery(sql) %}
+	 insert into {{ relation.include(database=(not temporary), schema=(not temporary)) }}
+	(
+	  {{ sql }}
+	)
+	;
   {%- else %}
-
-  create {% if temporary -%}temporary{%- endif %} table
-    {{ relation.include(database=(not temporary), schema=(not temporary)) }}
-    {% if backup == false -%}backup no{%- endif %}
-    {{ dist(_dist) }}
-    {{ sort(_sort_type, _sort) }}
   as (
     {{ sql }}
   );
-
   {%- endif %}
 {%- endmacro %}
 


### PR DESCRIPTION
cannot reference permanent table from temporary table constraint

resolves #
[[[docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose) dbt-labs/docs.getdbt.com/#](https://github.com/dbt-labs/dbt-redshift/issues/628)](https://github.com/dbt-labs/dbt-redshift/issues/628)


### Problem

cannot reference permanent table from temporary table constraint

### Solution

Implement change from https://github.com/dbt-labs/dbt-core/pull/8768 and https://github.com/dbt-labs/dbt-core/pull/8889 for Redshift

### Checklist

- [x ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ x] I have run this code in development and it appears to resolve the stated issue
- [ x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
