### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.changes/unreleased/Breaking Changes-20241016-190600.yaml
+++ b/.changes/unreleased/Breaking Changes-20241016-190600.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Drop support for Python 3.8
+time: 2024-10-16T19:06:00.668396-04:00
+custom:
+  Author: mikealfare
+  Issue: "931"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,7 +91,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2022]
-        python-version: ["3.8"]
+        python-version: ["3.9"]
         include:
           - os: ubuntu-22.04
             python-version: "3.9"
@@ -236,7 +236,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     env:
       TOXENV: integration-redshift

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install python dependencies
         run: |
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     env:
       TOXENV: "unit"
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install python dependencies
         run: |
@@ -174,7 +174,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2022]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -28,7 +28,7 @@ defaults:
     shell: "bash"
 
 env:
-  PYTHON_TARGET_VERSION: 3.8
+  PYTHON_TARGET_VERSION: 3.9
   NOTIFICATION_PREFIX: "[Internal Archive Release]"
   TEMP_PROFILE_NAME: "temp_aws_profile"
 

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -84,7 +84,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_TARGET_VERSION: 3.8
+  PYTHON_TARGET_VERSION: 3.9
   NOTIFICATION_PREFIX: "[Release Preparation]"
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     -   id: black
         args:
         -   --line-length=99
-        -   --target-version=py38
         -   --target-version=py39
         -   --target-version=py310
         -   --target-version=py311

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ $EDITOR test.env
 There are a few methods for running tests locally.
 
 #### `tox`
-`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel. For example, you can run unit tests for Python 3.8, Python 3.9, Python 3.10, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py38`. The configuration of these tests are located in `tox.ini`.
+`tox` takes care of managing Python virtualenvs and installing dependencies in order to run tests. You can also run tests in parallel. For example, you can run unit tests for Python 3.9 and Python 3.10, and `flake8` checks in parallel with `tox -p`. Also, you can run unit tests for specific python versions with `tox -e py39`. The configuration of these tests are located in `tox.ini`.
 
 #### `pytest`
 Finally, you can also run a specific test or group of tests using `pytest` directly. With a Python virtualenv active and dev dependencies installed you can do things like:

--- a/Makefile
+++ b/Makefile
@@ -38,14 +38,14 @@ linecheck: ## Checks for all Python lines 100 characters or more
 	find dbt -type f -name "*.py" -exec grep -I -r -n '.\{100\}' {} \;
 
 .PHONY: unit
-unit: ## Runs unit tests with py38.
+unit: ## Runs unit tests with py39.
 	@\
-	tox -e py38
+	tox -e py39
 
 .PHONY: test
 test: ## Runs unit tests with py38 and code checks against staged changes.
 	@\
-	tox -p -e py38; \
+	tox -p -e py39; \
 	pre-commit run black-check --hook-stage manual | grep -v "INFO"; \
 	pre-commit run flake8-check --hook-stage manual | grep -v "INFO"; \
 	pre-commit run mypy-check --hook-stage manual | grep -v "INFO"
@@ -53,7 +53,7 @@ test: ## Runs unit tests with py38 and code checks against staged changes.
 .PHONY: integration
 integration: ## Runs redshift integration tests with py38.
 	@\
-	tox -e py38-redshift --
+	tox -e py39-redshift --
 
 .PHONY: clean
 	@echo "cleaning repo"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,8 +7,7 @@ git+https://github.com/dbt-labs/dbt-postgres.git
 
 # dev
 ipdb~=0.13.13
-pre-commit~=3.7.0;python_version >="3.9"
-pre-commit~=3.5.0;python_version <"3.9"
+pre-commit~=3.7.0
 
 # test
 ddtrace==2.3.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # this image gets published to GHCR for production use
 ARG py_version=3.11.2
 
-FROM python:$py_version-slim-bullseye as base
+FROM python:$py_version-slim-bullseye AS base
 
 RUN apt-get update \
   && apt-get dist-upgrade -y \
@@ -25,7 +25,7 @@ ENV LANG=C.UTF-8
 RUN python -m pip install --upgrade "pip==24.0" "setuptools==69.2.0" "wheel==0.43.0" --no-cache-dir
 
 
-FROM base as dbt-redshift
+FROM base AS dbt-redshift
 
 ARG commit_ref=main
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,43 +1,43 @@
 # this image does not get published, it is intended for local development only, see `Makefile` for usage
-FROM ubuntu:22.04 as base
+FROM ubuntu:24.04 as base
 
 # prevent python installation from asking for time zone region
 ARG DEBIAN_FRONTEND=noninteractive
 
 # add python repository
 RUN apt-get update \
-  && apt-get install -y software-properties-common=0.99.22.9 \
-  && add-apt-repository -y ppa:deadsnakes/ppa \
-  && apt-get clean \
-  && rm -rf \
-    /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
+    && apt-get install -y software-properties-common=0.99.48 \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get clean \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/*
 
 # install python
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    build-essential=12.9ubuntu3 \
-    git-all=1:2.34.1-1ubuntu1.10 \
-    python3.8=3.8.19-1+jammy1 \
-    python3.8-dev=3.8.19-1+jammy1 \
-    python3.8-distutils=3.8.19-1+jammy1 \
-    python3.8-venv=3.8.19-1+jammy1 \
-    python3-pip=22.0.2+dfsg-1ubuntu0.4 \
-    python3-wheel=0.37.1-2ubuntu0.22.04.1 \
-  && apt-get clean \
-  && rm -rf \
-    /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
+    && apt-get install -y --no-install-recommends \
+        build-essential=12.10ubuntu1 \
+        git-all=1:2.43.0-1ubuntu7.1 \
+        python3.9=3.9.20-1+noble1 \
+        python3.9-dev=3.9.20-1+noble1 \
+        python3.9-distutils=3.9.20-1+noble1 \
+        python3.9-venv=3.9.20-1+noble1 \
+        python3-pip=24.0+dfsg-1ubuntu1 \
+        python3-wheel=0.42.0-2 \
+    && apt-get clean \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/*
 
 # update the default system interpreter to the newly installed version
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
 
 
 FROM base as dbt-redshift-dev
 
-HEALTHCHECK CMD python3 --version || exit 1
+HEALTHCHECK CMD python --version || exit 1
 
 # send stdout/stderr to terminal
 ENV PYTHONUNBUFFERED=1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import sys
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 9):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.8 or higher.")
+    print("Please upgrade to Python 3.9 or higher.")
     sys.exit(1)
 
 
@@ -67,11 +67,10 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py38,py39,py310,py311,py312
+envlist = py39,py310,py311,py312
 
-[testenv:{unit,py38,py39,py310,py311,py312,py}]
+[testenv:{unit,py39,py310,py311,py312,py}]
 description = unit testing
 skip_install = true
 passenv =
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py38,py39,py310,py311,py312,py}-{redshift}]
+[testenv:{integration,py39,py310,py311,py312,py}-{redshift}]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
### Problem

Python 3.8 reached end of life on 10/7/2024.

### Solution

Drop support for Python 3.8. Update tests to no longer run on Python 3.8.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX