### PR TITLE
[Backport 1.4.latest] Drop support for Python 3.8 #2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@
 # TODO: remove global exclusion of tests when testing overhaul is complete
 exclude: '^tests/.*'
 
-# Force all unspecified python hooks to run python 3.8
+# Force all unspecified python hooks to run python 3.9
 default_language_version:
-  python: python3.8
+  python: python3.9
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
Backport #931 addition

The python version was specified in `.pre-commit-config.yml`, which was missed during the backport as this is not the case in newer versions.