### PR TITLE
[Bug 1.8.latest] Pin build dependencies to final releases

### DIFF
--- a/.changes/unreleased/Fixes-20241023-104556.yaml
+++ b/.changes/unreleased/Fixes-20241023-104556.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Pin build dependencies to final releases
+time: 2024-10-23T10:45:56.816922-04:00
+custom:
+  Author: mikealfare
+  Issue: "930"

--- a/setup.py
+++ b/setup.py
@@ -59,14 +59,14 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-common>=0.1.0a1,<2.0",
-        "dbt-adapters>=0.1.0a1,<2.0",
+        "dbt-common>=0.1.0,<2.0",
+        "dbt-adapters>=0.1.0,<2.0",
         f"dbt-postgres~={_plugin_version_trim()}",
         # dbt-redshift depends deeply on this package. it does not follow SemVer, therefore there have been breaking changes in previous patch releases
         # Pin to the patch or minor version, and bump in each new minor version of dbt-redshift.
         "redshift-connector<2.0.918,>=2.0.913,!=2.0.914",
         # add dbt-core to ensure backwards compatibility of installation, this is not a functional dependency
-        "dbt-core>=1.8.0b3",
+        "dbt-core>=1.8.0",
         # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
         "sqlparse>=0.5.0,<0.6.0",
         "agate",


### PR DESCRIPTION
resolves #930

### Problem

We never pinned build dependencies to final releases when creating the minor branch.

### Solution

Pin `dbt-common`, `dbt-adapters`, and `dbt-core` to final releases to avoid getting pre-releases (e.g. 1.9.0b1).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX