### PR TITLE
Test `macos-14` on Python 3.10 instead of Python 3.9 due to missing `psycopg2-binary`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,17 +90,14 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2022]
-        python-version: ["3.9"]
+        os: ubuntu-22.04
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: ubuntu-22.04
-            python-version: "3.9"
-          - os: ubuntu-22.04
+          # psycopg2-binary doesn't have a precompiled wheel for python 3.9 for macos-14
+          - os: macos-14
             python-version: "3.10"
-          - os: ubuntu-22.04
-            python-version: "3.11"
-          - os: ubuntu-22.04
-            python-version: "3.12"
+          - os: windows-2022
+            python-version: "3.9"
 
     env:
       TOXENV: integration-redshift


### PR DESCRIPTION
### Problem

`psycopg2-binary` did not publish a wheel for Python 3.9 on `macos-14`.

### Solution

Test `macos-14` against Python 3.10.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
