### PR TITLE
Tidy: fix typo in test class name

### DIFF
--- a/tests/functional/adapter/incremental/test_incremental_microbatch.py
+++ b/tests/functional/adapter/incremental/test_incremental_microbatch.py
@@ -11,7 +11,7 @@ select * from {{ ref('input_model') }}
 """
 
 
-class TestSnowflakeMicrobatch(BaseMicrobatch):
+class TestRedshiftMicrobatch(BaseMicrobatch):
     @pytest.fixture(scope="class")
     def microbatch_model_sql(self) -> str:
         return _microbatch_model_no_unique_id_sql


### PR DESCRIPTION
### Problem

The test class name [here](https://github.com/dbt-labs/dbt-redshift/blob/f83885ffb12d9d6e6dc847a5f21a103da3685227/tests/functional/adapter/incremental/test_incremental_microbatch.py#L14) has `Snowflake` instead of `Redshift`.

### Solution

Update the name of the test class. This has no functional change, just a readability one.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] Tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
