### PR TITLE
Refactor to use new batch context varaibles

### DIFF
--- a/.changes/unreleased/Under the Hood-20241211-145132.yaml
+++ b/.changes/unreleased/Under the Hood-20241211-145132.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Refactor to use new batch context varaibles
+time: 2024-12-11T14:51:32.239224-06:00
+custom:
+  Author: QMalcolm
+  Issue: "966"

--- a/dbt/include/redshift/macros/materializations/incremental_merge.sql
+++ b/dbt/include/redshift/macros/materializations/incremental_merge.sql
@@ -89,13 +89,13 @@
         {% do predicates.append(pred) %}
     {% endfor %}
 
-    {% if not model.config.get("__dbt_internal_microbatch_event_time_start") or not model.config.get("__dbt_internal_microbatch_event_time_end") -%}
+    {% if not model.batch or (not model.batch.event_time_start or not model.batch.event_time_end) -%}
         {% do exceptions.raise_compiler_error('dbt could not compute the start and end timestamps for the running batch') %}
     {% endif %}
 
     {#-- Add additional incremental_predicates to filter for batch --#}
-    {% do predicates.append(model.config.event_time ~ " >= TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_start ~ "'") %}
-    {% do predicates.append(model.config.event_time ~ " < TIMESTAMP '" ~ model.config.__dbt_internal_microbatch_event_time_end ~ "'") %}
+    {% do predicates.append(model.config.event_time ~ " >= TIMESTAMP '" ~ model.batch.event_time_start ~ "'") %}
+    {% do predicates.append(model.config.event_time ~ " < TIMESTAMP '" ~ model.batch.event_time_end ~ "'") %}
     {% do arg_dict.update({'incremental_predicates': predicates}) %}
 
     delete from {{ target }}


### PR DESCRIPTION
resolves #966

### Problem

During the betas/rcs of dbt-core 1.9.0, the varaibles `__dbt_internal_event_time_start` and `__dbt_internal_event_time_end` were available on the model in the jinja context. However when the final of dbt-core 1.9.0 was released, dbt-core started providing a `batch` object on the model available in the jinja context. This batch object made availble all the prevous information and more, and it is the "correct" way to get the information (i.e. `__dbt_internal_event_time_end` and `__dbt_internal_event_time_start` are deprecated.

### Solution

Update the microbatch incremental strategies to use `model.batch.<variable>` variables

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
