### PR TITLE
Add Redshift Iam Idc token authentication method with an eye towards future supported Idps 

### DIFF
--- a/.changes/unreleased/Features-20241217-181340.yaml
+++ b/.changes/unreleased/Features-20241217-181340.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add IdpTokenAuthPlugin authentication method.
+time: 2024-12-17T18:13:40.281494-08:00
+custom:
+    Author: versusfacit
+    Issue: "898"

--- a/dbt/adapters/redshift/auth_providers.py
+++ b/dbt/adapters/redshift/auth_providers.py
@@ -1,0 +1,87 @@
+import requests
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Dict, Any
+
+from dbt.adapters.exceptions import FailedToConnectError
+from dbt_common.exceptions import DbtRuntimeError
+
+
+# Define an Enum for the supported token endpoint types
+class TokenServiceBase(ABC):
+    def __init__(self, token_endpoint: Dict[str, Any]):
+        expected_keys = {"type", "request_url", "request_data"}
+        for key in expected_keys:
+            if key not in token_endpoint:
+                raise FailedToConnectError(f"Missing required key in token_endpoint: '{key}'")
+
+        self.type: str = token_endpoint["type"]
+        self.url: str = token_endpoint["request_url"]
+        self.data: str = token_endpoint["request_data"]
+
+        self.other_params = {k: v for k, v in token_endpoint.items() if k not in expected_keys}
+
+    @abstractmethod
+    def build_header_payload(self) -> Dict[str, Any]:
+        pass
+
+    def handle_request(self) -> requests.Response:
+        """
+        Handles the request with rate limiting and error handling.
+        """
+        response = requests.post(self.url, headers=self.build_header_payload(), data=self.data)
+
+        if response.status_code == 429:
+            raise DbtRuntimeError(
+                "Rate limit on identity provider's token dispatch has been reached. "
+                "Consider increasing your identity provider's refresh token rate or "
+                "lower dbt's maximum concurrent thread count."
+            )
+
+        response.raise_for_status()
+        return response
+
+
+class OktaIdpTokenService(TokenServiceBase):
+    def build_header_payload(self) -> Dict[str, Any]:
+        if encoded_idp_client_creds := self.other_params.get("idp_auth_credentials"):
+            return {
+                "accept": "application/json",
+                "authorization": f"Basic {encoded_idp_client_creds}",
+                "content-type": "application/x-www-form-urlencoded",
+            }
+        else:
+            raise FailedToConnectError(
+                "Missing 'idp_auth_credentials' from token_endpoint. Please provide client_id:client_secret in base64 encoded format as a profile entry under token_endpoint."
+            )
+
+
+class EntraIdpTokenService(TokenServiceBase):
+    """
+    formatted based on docs: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#refresh-the-access-token
+    """
+
+    def build_header_payload(self) -> Dict[str, Any]:
+        return {
+            "accept": "application/json",
+            "content-type": "application/x-www-form-urlencoded",
+        }
+
+
+class TokenServiceType(Enum):
+    OKTA = "okta"
+    ENTRA = "entra"
+
+
+def create_token_service_client(token_endpoint: Dict[str, Any]) -> TokenServiceBase:
+    if (service_type := token_endpoint.get("type")) is None:
+        raise FailedToConnectError("Missing required key in token_endpoint: 'type'")
+
+    if service_type == TokenServiceType.OKTA.value:
+        return OktaIdpTokenService(token_endpoint)
+    elif service_type == TokenServiceType.ENTRA.value:
+        return EntraIdpTokenService(token_endpoint)
+    else:
+        raise ValueError(
+            f"Unsupported identity provider type: {service_type}. Select 'okta' or 'entra.'"
+        )

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -357,7 +357,7 @@ def get_connection_method(
 
         logger.debug("Connecting to Redshift with '{credentials.method}' credentials method")
 
-        __validate_required_fields("iam_idc_token", ("token_endpoint",))
+        __validate_required_fields("oauth_token_identity_center", ("token_endpoint",))
 
         required_keys = {"request_url", "idp_auth_credentials", "request_data"}
         if required_keys - credentials.token_endpoint.keys():

--- a/dbt/adapters/redshift/connections.py
+++ b/dbt/adapters/redshift/connections.py
@@ -329,12 +329,11 @@ def get_connection_method(
 
     def __iam_idc_token_kwargs(credentials) -> Dict[str, Any]:
         """
-        Expand the logic and flow control here to account for other Identity providers
-        with their specific request configurations. May require new parameters for
-        token_endpoint extraction to distinguish idp's if the url is insufficient.
+        Accepts a `credentials` object with a `token_endpoint` field that corresponds to
+        either Okta or Entra authentication services.
 
         We only support token_type=EXT_JWT tokens. token_type=ACCESS_TOKEN has not been
-        tested or is supported but can be added with a presenting use-case.
+        tested. It can be added with a presenting use-case.
         """
 
         logger.debug("Connecting to Redshift with '{credentials.method}' credentials method")

--- a/hatch.toml
+++ b/hatch.toml
@@ -11,18 +11,19 @@ packages = ["dbt"]
 dependencies = [
     "dbt-adapters @ git+https://github.com/dbt-labs/dbt-adapters.git",
     "dbt-common @ git+https://github.com/dbt-labs/dbt-common.git",
-    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter",
     "dbt-core @ git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core",
+    "dbt-tests-adapter @ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter",
     "ddtrace==2.3.0",
+    "freezegun",
     "ipdb~=0.13.13",
     "pre-commit==3.7.0",
-    "freezegun",
-    "pytest>=7.0,<8.0",
     "pytest-csv~=3.0",
     "pytest-dotenv",
     "pytest-logbook~=1.2",
     "pytest-mock",
     "pytest-xdist",
+    "pytest>=7.0,<8.0",
+    "requests",
 ]
 
 [envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     # installed via dbt-core but referenced directly; don't pin to avoid version conflicts with dbt-core
     "sqlparse>=0.5.0,<0.6.0",
     "agate",
+    "requests",
 ]
 
 [project.urls]

--- a/tests/functional/test_auth_method.py
+++ b/tests/functional/test_auth_method.py
@@ -117,6 +117,7 @@ class TestIamIdcAuthProfileOktaIdp(AuthMethod):
             "dbname": "dev",
             "threads": 1,
             "token_endpoint": {
+                "type": "okta",
                 "request_url": "https://<subdomain>.oktapreview.com/oauth2/default/v1/token",
                 "idp_auth_credentials": "<base64 creds>",
                 "request_data": "grant_type=refresh_token&redirect_uri=<encoded redirect uri>&refresh_token=<a refresh token>",

--- a/tests/functional/test_auth_method.py
+++ b/tests/functional/test_auth_method.py
@@ -101,3 +101,24 @@ class TestIAMRoleAuthProfile(AuthMethod):
             "host": "",  # host is a required field in dbt-core
             "port": 0,  # port is a required field in dbt-core
         }
+
+
+@pytest.mark.skip(
+    reason="We need to cut over to new adapters team AWS account which has infra to support this as an automated test. This will include a GHA step that renders a refresh token and loading secrets into Github secrets for the <> delimited placeholder values below"
+)
+class TestIamIdcAuthProfileOktaIdp(AuthMethod):
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self):
+        return {
+            "type": "redshift",
+            "method": "oauth_token_identity_center",
+            "host": os.getenv("REDSHIFT_TEST_HOST"),
+            "port": 5439,
+            "dbname": "dev",
+            "threads": 1,
+            "token_endpoint": {
+                "request_url": "https://<subdomain>.oktapreview.com/oauth2/default/v1/token",
+                "idp_auth_credentials": "<base64 creds>",
+                "request_data": "grant_type=refresh_token&redirect_uri=<encoded redirect uri>&refresh_token=<a refresh token>",
+            },
+        }

--- a/tests/unit/test_auth_method.py
+++ b/tests/unit/test_auth_method.py
@@ -695,11 +695,13 @@ class TestIAMIdcToken(AuthMethod):
         )
         with self.assertRaises(requests.exceptions.HTTPError) as context:
             """
-            http says we've made it in operation to call the token request which fails
+            An http says we've made it in operation to call the token request which fails
             due to invalid refresh token and auth creds
             """
             connection = self.adapter.acquire_connection("dummy")
             connection.handle
+
+        assert "401 Client Error: Unauthorized for url" in str(context.exception)
 
     @mock.patch("redshift_connector.connect", MagicMock())
     def test_invalid_idc_token_missing_field(self):


### PR DESCRIPTION
resolves #898 


### Problem

Add `refresh_token`-based authentication method. `refresh_token` allows for use of Iam Idc tokens that we generate adhoc for the `redshift_connector.connect` call. We had originally sought to provide a single access token and reuse it until TTL reached, but this is impossible -- tokens are only good for one use in this integration. Hence we must adhoc generate one each time and refresh tokens are an expedient and industry compliant method for doing so

### Solution

Provide a refresh token endpoint and necessary information to enable this.

### Additional testing

End to end test using the following profile which points to a test redshift cluster on an AWS account with an integrated Okta <> Iam idc <> Redshift token authentication suite.

![image](https://github.com/user-attachments/assets/0611e45c-71e8-4328-b367-c186b60a8a23)

```
class TestMyTest:
    @pytest.fixture(scope="class")
    def models(self):
        return {
            "base_table.sql": "{{ config(materialized='table') }} select 1 as id",
        }

    @pytest.fixture(scope="class")
    def dbt_profile_target(self):
        return {
            "type": "redshift",
            "host": "...",
            "port": 5439,
            "dbname": "dev",
            "threads": 1,
            "token_endpoint": {
                "request_url": "https://....oktapreview.com/oauth2/default/v1/token",
                "idp_auth_credentials": ...,
                "request_data": 'grant_type=refresh_token&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Flogin%2Foauth2%2Fcode%2Fokta&refresh_token=...'

            },
            "method": "oauth_token_identity_center",
            "schema": "dbt_mila",
        }


    def test_my_test(self, project):
        run_dbt()
```

where `...` is some credential I've used for testing.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-core/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] This PR has no interface changes (e.g. macros, cli, logs, json artifacts, config files, adapter interface, etc) or this PR has already received feedback and approval from Product or DX
