### PR TITLE
[Backport 1.9.latest] Combine the build and check build jobs into one job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,8 @@ jobs:
           python -m pip install --user --upgrade pip
           python -m pip install --upgrade setuptools wheel twine check-wheel-contents
           python -m pip --version
+      - if: matrix.os == 'macos-14'
+        run: brew install postgresql@14
       - run: ./scripts/build-dist.sh
       - run: ls -lh dist/
       - run: twine check dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,98 +104,43 @@ jobs:
         run: |
           echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT
 
-  build:
-    name: build packages
-
-    runs-on: ubuntu-latest
-
-    outputs:
-      is_alpha: ${{ steps.check-is-alpha.outputs.is_alpha }}
-
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install  --user --upgrade pip
-          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
-          python -m pip --version
-
-      - name: Build distributions
-        run: ./scripts/build-dist.sh
-
-      - name: Show distributions
-        run: ls -lh dist/
-
-      - name: Check distribution descriptions
-        run: |
-          twine check dist/*
-
-      - name: Check wheel contents
-        run: |
-          check-wheel-contents dist/*.whl --ignore W007,W008
-
-      - name: Check if this is an alpha version
-        id: check-is-alpha
-        run: |
-          export is_alpha=0
-          if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
-          echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
-
   test-build:
     name: verify packages / python ${{ matrix.python-version }} / ${{ matrix.os }}
-
-    if: needs.build.outputs.is_alpha == 0
-
-    needs: build
-
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-14, windows-2022]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        dist-type: ["whl", "gz"]
         exclude:
           # psycopg2-binary doesn't have a precompiled wheel for python 3.9 for mac
           - os: macos-14
             python-version: '3.9'
-
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
         with:
-          python-version: ${{ matrix.python-version }}
-
+          persist-credentials: false
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: Install python dependencies
         run: |
-          python -m pip install  --user --upgrade pip
-          python -m pip install --upgrade wheel
+          python -m pip install --user --upgrade pip
+          python -m pip install --upgrade setuptools wheel twine check-wheel-contents
           python -m pip --version
-
-      - name: Show distributions
-        run: ls -lh dist/
-
-      - name: Install wheel distributions
+      - run: ./scripts/build-dist.sh
+      - run: ls -lh dist/
+      - run: twine check dist/*
+      - run: check-wheel-contents dist/*.whl --ignore W007,W008
+      - id: check-is-alpha
         run: |
-          find ./dist/*.whl -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: Check wheel distributions
-        run: |
-          python -c "import dbt.adapters.redshift"
-
-      - name: Install source distributions
-        run: |
-          find ./dist/*.gz -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
-
-      - name: Check source distributions
-        run: |
-          python -c "import dbt.adapters.redshift"
+          export is_alpha=0
+          if [[ "$(ls -lh dist/)" == *"a1"* ]]; then export is_alpha=1; fi
+          echo "is_alpha=$is_alpha" >> $GITHUB_OUTPUT
+      - name: Install ${{ matrix.dist-type }} distributions
+        if: ${{ steps.check-is-alpha.outputs.is_alpha == 0 }}
+        run: find ./dist/*.${{ matrix.dist-type }} -maxdepth 1 -type f | xargs python -m pip install --force-reinstall --find-links=dist/
+      - name: Check ${{ matrix.dist-type }} distributions
+        if: ${{ steps.check-is-alpha.outputs.is_alpha == 0 }}
+        run: python -c "import dbt.adapters.redshift"


### PR DESCRIPTION
Backport of #985, but using the `setup.py` based build tools instead of `pyproject.toml` build tools.