### PR TITLE
[Backport 1.5.latest] Remove upload steps

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -190,23 +190,11 @@ jobs:
           DBT_TEST_USER_3: dbt_test_user_3
         run: tox -- --ddtrace
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: logs
-          path: ./logs
-
       - name: Get current date
         if: always()
         id: date
         run: |
           echo "date=$(date +'%Y-%m-%dT%H_%M_%S')" >> $GITHUB_OUTPUT #no colons allowed for artifacts
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: integration_results_${{ matrix.python-version }}_${{ matrix.os }}_${{ matrix.adapter }}-${{ steps.date.outputs.date }}.csv
-          path: integration_results.csv
 
   require-label-comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
actions/upload-artifact@v3 was retired and `v4` is not backwards compatible. Since we don't use the upload it's safe to simply remove it.